### PR TITLE
Add public shared skill/plugin ports

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,6 +39,51 @@
         "openscad",
         "gridfinity"
       ]
+    },
+    {
+      "name": "deep-dive",
+      "description": "Opinionated, actionable analysis on any topic. Delivers ONE clear recommendation grounded in the user's actual stack — not a menu of options. Auto-detects topic category (operational, architecture, strategy, security, workflow), scales to quick/standard/exhaustive depth, and pulls live docs via find-docs when available.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Ossie Irondi"
+      },
+      "source": "./claude-code/plugins/deep-dive",
+      "category": "analysis",
+      "license": "MIT",
+      "keywords": ["analysis", "deep-dive", "decision-making", "advisory", "expert-opinion", "code-review"]
+    },
+    {
+      "name": "ask-codex",
+      "description": "OpenAI Codex CLI integration for Claude Code. Wraps `codex exec` and `codex resume` with model selection (gpt-5.4 / gpt-5.3-codex / gpt-5.4-nano), reasoning effort control, sandbox modes, session resumption, and stderr suppression. Requires the `codex` binary on PATH.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Ossie Irondi"
+      },
+      "source": "./claude-code/plugins/ask-codex",
+      "category": "analysis",
+      "license": "MIT",
+      "keywords": ["codex", "openai", "code-analysis", "refactoring", "cli-integration", "external-services"]
+    },
+    {
+      "name": "skill-stats",
+      "description": "Telemetry-driven report on Claude Code skill usage. Bundles a PreToolUse hook that logs every Skill invocation to a plugin-owned JSONL file, plus a report generator that surfaces top-used, recently-active, dormant, and phantom skills. Uses ${CLAUDE_PLUGIN_DATA} for storage so it survives plugin updates.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Ossie Irondi"
+      },
+      "source": "./claude-code/plugins/skill-stats",
+      "category": "infrastructure",
+      "license": "MIT",
+      "keywords": [
+        "telemetry",
+        "skills",
+        "claude-code",
+        "harness",
+        "introspection",
+        "infrastructure",
+        "dormancy",
+        "pruning"
+      ]
     }
   ]
 }

--- a/claude-code/plugins/ask-codex/.claude-plugin/plugin.json
+++ b/claude-code/plugins/ask-codex/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "ask-codex",
+  "version": "0.1.0",
+  "description": "OpenAI Codex CLI integration for Claude Code. Wraps `codex exec` and `codex resume` with model selection (gpt-5.4 / gpt-5.3-codex / gpt-5.4-nano), reasoning effort control (high/medium/low), sandbox modes (read-only / workspace-write / danger-full-access), session resumption, and stderr suppression for thinking tokens.",
+  "author": {
+    "name": "Ossie Irondi"
+  },
+  "homepage": "https://github.com/AojdevStudio/agentic-utilities/tree/main/claude-code/plugins/ask-codex",
+  "repository": "https://github.com/AojdevStudio/agentic-utilities",
+  "license": "MIT",
+  "keywords": ["codex", "openai", "code-analysis", "refactoring", "cli-integration", "external-services"]
+}

--- a/claude-code/plugins/ask-codex/README.md
+++ b/claude-code/plugins/ask-codex/README.md
@@ -1,0 +1,43 @@
+# ask-codex
+
+OpenAI Codex CLI integration for Claude Code. Hand off code analysis, refactoring, and automated edits to the Codex CLI without leaving your Claude Code session.
+
+## What it does
+
+Auto-activates when you mention "codex", "codex cli", "codex exec", "codex resume", or "ask codex". The skill:
+
+- Prompts for **model** (`gpt-5.4` / `gpt-5.3-codex` / `gpt-5.4-nano`) and **reasoning effort** (`high` / `medium` / `low`) in a single batched question.
+- Picks the right **sandbox mode** for the task: `read-only` (default, analysis), `workspace-write` (local edits), or `danger-full-access` (network-enabled).
+- Always passes `--skip-git-repo-check` and pipes stderr to `/dev/null` so Codex's thinking tokens don't pollute the chat.
+- Supports **session resumption** via `codex exec resume --last` — the resumed session inherits the original model + reasoning + sandbox.
+- Asks for permission before invoking high-impact flags (`--full-auto`, `--sandbox danger-full-access`).
+
+## Prerequisites
+
+The `codex` CLI must be installed and authenticated on the host:
+
+```bash
+# install (one-time)
+npm install -g @openai/codex
+# or follow OpenAI's current install instructions
+
+# verify
+codex --version
+```
+
+Without `codex` on PATH the skill will surface the failure and stop.
+
+## Trigger phrases
+
+- "ask codex to review …"
+- "use codex to refactor X"
+- "codex resume"
+- "run this through codex"
+
+## Safety
+
+The skill defaults to `read-only` sandbox and asks before escalating to `workspace-write` or `danger-full-access`. Resume operations don't auto-pass new flags — the user must explicitly request a model/effort change.
+
+## License
+
+MIT — see repository LICENSE.

--- a/claude-code/plugins/ask-codex/skills/ask-codex/SKILL.md
+++ b/claude-code/plugins/ask-codex/skills/ask-codex/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: ask-codex
+description: OpenAI Codex CLI integration for code analysis and editing. Use when the user mentions "codex", "codex cli", "codex exec", "codex resume", "ask codex", or wants to delegate code analysis, refactoring, or automated editing to the Codex CLI. Requires the `codex` binary on PATH.
+---
+
+# Ask Codex Skill
+
+Wraps the OpenAI Codex CLI (`codex exec`, `codex resume`) with explicit model + reasoning + sandbox selection so Claude Code can hand off work to Codex when its strengths fit (long-running agentic edits, GPT-5.x reasoning, network-enabled tasks).
+
+**Prerequisite:** the `codex` CLI must be installed and authenticated on the host. Verify with `codex --version` before the first run.
+
+---
+
+## Running a Task
+
+1. Ask the user (via `AskUserQuestion`) which model to run (`gpt-5.4` (Recommended — 25% faster, most capable agentic coding model), `gpt-5.3-codex`, or `gpt-5.4-nano`) AND which reasoning effort to use (`high`, `medium`, or `low`) in a **single prompt with two questions**.
+2. Select the sandbox mode required for the task; default to `--sandbox read-only` unless edits or network access are necessary.
+3. Assemble the command with the appropriate options:
+   - `-m, --model <MODEL>`
+   - `--config model_reasoning_effort="<high|medium|low>"`
+   - `--sandbox <read-only|workspace-write|danger-full-access>`
+   - `--full-auto`
+   - `-C, --cd <DIR>`
+   - `--skip-git-repo-check`
+4. Always use `--skip-git-repo-check`.
+5. When continuing a previous session, use `codex exec --skip-git-repo-check resume --last` via stdin. When resuming don't use any configuration flags unless explicitly requested by the user (e.g. if the user specifies the model or the reasoning effort when requesting to resume a session). Resume syntax: `echo "your prompt here" | codex exec --skip-git-repo-check resume --last 2>/dev/null`. All flags have to be inserted between `exec` and `resume`.
+6. **IMPORTANT:** By default, append `2>/dev/null` to all `codex exec` commands to suppress thinking tokens (stderr). Only show stderr if the user explicitly requests to see thinking tokens or if debugging is needed.
+7. Run the command, capture stdout/stderr (filtered as appropriate), and summarize the outcome for the user.
+8. **After Codex completes**, inform the user: "You can resume this Codex session at any time by saying 'codex resume' or asking me to continue with additional analysis or changes."
+
+### Quick Reference
+
+| Use case | Sandbox mode | Key flags |
+| --- | --- | --- |
+| Read-only review or analysis | `read-only` | `--sandbox read-only 2>/dev/null` |
+| Apply local edits | `workspace-write` | `--sandbox workspace-write --full-auto 2>/dev/null` |
+| Permit network or broad access | `danger-full-access` | `--sandbox danger-full-access --full-auto 2>/dev/null` |
+| Resume recent session | Inherited from original | `echo "prompt" \| codex exec --skip-git-repo-check resume --last 2>/dev/null` (no flags allowed) |
+| Run from another directory | Match task needs | `-C <DIR>` plus other flags `2>/dev/null` |
+
+## Following Up
+
+- After every `codex` command, immediately use `AskUserQuestion` to confirm next steps, collect clarifications, or decide whether to resume with `codex exec resume --last`.
+- When resuming, pipe the new prompt via stdin: `echo "new prompt" | codex exec resume --last 2>/dev/null`. The resumed session automatically uses the same model, reasoning effort, and sandbox mode from the original session.
+- Restate the chosen model, reasoning effort, and sandbox mode when proposing follow-up actions.
+
+## Error Handling
+
+- Stop and report failures whenever `codex --version` or a `codex exec` command exits non-zero; request direction before retrying.
+- Before you use high-impact flags (`--full-auto`, `--sandbox danger-full-access`, `--skip-git-repo-check`) ask the user for permission using `AskUserQuestion` unless it was already given.
+- When output includes warnings or partial results, summarize them and ask how to adjust using `AskUserQuestion`.

--- a/claude-code/plugins/deep-dive/.claude-plugin/plugin.json
+++ b/claude-code/plugins/deep-dive/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "deep-dive",
+  "version": "0.1.0",
+  "description": "Opinionated, actionable analysis on any topic. Delivers ONE clear recommendation grounded in the user's actual stack — not a menu of options. Auto-detects topic category (operational, architecture, strategy, security, workflow), scales to quick/standard/exhaustive depth, and pulls live docs via find-docs when available.",
+  "author": {
+    "name": "Ossie Irondi"
+  },
+  "homepage": "https://github.com/AojdevStudio/agentic-utilities/tree/main/claude-code/plugins/deep-dive",
+  "repository": "https://github.com/AojdevStudio/agentic-utilities",
+  "license": "MIT",
+  "keywords": ["analysis", "deep-dive", "decision-making", "advisory", "expert-opinion", "code-review"]
+}

--- a/claude-code/plugins/deep-dive/README.md
+++ b/claude-code/plugins/deep-dive/README.md
@@ -1,0 +1,32 @@
+# deep-dive
+
+Opinionated, actionable analysis on any topic — delivered as **one clear path forward**, not a menu of options.
+
+## What it does
+
+The skill auto-activates when you ask for a deep dive, breakdown, audit, policy, or expert rundown on any topic. It:
+
+1. **Scans your project context** (package.json, monorepo files, README, dir structure) to ground advice in your actual stack.
+2. **Fetches live documentation** via the `find-docs` skill (Context7) for any tool/framework mentioned, so advice doesn't go stale.
+3. **Challenges the premise** before optimizing — if your assumed tool isn't the best fit, it says so first and recommends the winner.
+4. **Auto-classifies the topic** into one of five categories (operational, architecture, strategy, security, workflow) and pulls the relevant section structure.
+5. **Scales depth** to your phrasing: Quick (~500 words, decision only), Standard (~2000 words, structured), or Exhaustive (~3500 words, every angle).
+6. **Returns one recommendation per question** with a brief justification — never "Option A vs B vs C."
+
+## Trigger phrases
+
+- "deep dive into X"
+- "break this down for me"
+- "audit my approach to X"
+- "give me a thorough breakdown of X"
+- "how should I manage X"
+- "create a policy for X"
+- "expert rundown on X"
+
+## Optional companion
+
+If you have a `find-docs` (Context7) skill installed, deep-dive will use it automatically to pull current docs before writing. Without it, the skill proceeds on training knowledge and flags areas to verify.
+
+## License
+
+MIT — see repository LICENSE.

--- a/claude-code/plugins/deep-dive/skills/deep-dive/SKILL.md
+++ b/claude-code/plugins/deep-dive/skills/deep-dive/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: deep-dive
+description: "USE WHEN: deep dive into X, break this down for me, audit my approach, give me a thorough breakdown, how should I manage X, create a policy for X, expert rundown on X. Delivers structured opinionated analysis with one clear path forward."
+---
+
+# Deep Dive Skill
+
+Deliver comprehensive, opinionated, actionable analysis on any topic. The core value
+proposition: the user gets ONE clear path forward, grounded in their actual context and
+current documentation — not a menu of options to choose from.
+
+---
+
+## Step 1: Detect Context and Fetch Live Docs
+
+### 1a: Scan project context (Claude Code only)
+
+When running in Claude Code with file system access, scan for project context before starting:
+
+```
+Check for:
+- package.json / bun.lock / Cargo.toml / pyproject.toml -> stack & package manager
+- monorepo indicators (workspaces field, pnpm-workspace.yaml, turbo.json)
+- .env files -> infrastructure hints (DB, cloud provider, etc.)
+- README.md -> project description and architecture notes
+- Directory structure (src/, apps/, packages/) -> project shape
+```
+
+Use what you find to ground the deep dive in the user's actual setup. Reference specific
+files, configs, and dependency versions when relevant. If no file system is available
+(Claude.ai), skip this step and work from what the user provides conversationally.
+
+### 1b: Fetch current documentation (Claude Code only)
+
+When the topic involves specific tools, frameworks, or services, use the `find-docs` skill
+(Context7 CLI) to pull up-to-date documentation BEFORE writing the analysis. This prevents
+stale advice from training data. For example:
+
+- Topic mentions Supabase -> fetch current Supabase docs for the relevant feature
+- Topic mentions Bun workspaces -> fetch current Bun workspace docs
+- Topic mentions Vercel env vars -> fetch current Vercel environment variable docs
+
+This is important because tools evolve fast. The user deserves advice grounded in the
+current API, not last year's. If `find-docs` is not available, proceed with training
+knowledge but note where documentation should be verified.
+
+---
+
+## Step 2: Challenge the Premise
+
+Before diving into "how to do X with Y," evaluate whether Y is the right tool. The user
+may have inherited a stack choice, copied a tutorial, or picked something without comparing
+alternatives. A deep dive that optimizes the wrong approach is worse than useless.
+
+**What this looks like in practice:**
+
+- User says "manage lockfiles in my Bun monorepo" -> First ask: is Bun actually the best
+  monorepo tool for your situation? Compare Bun vs pnpm vs yarn workspaces. Pick the winner
+  based on the user's actual constraints (team size, ecosystem needs, build speed). THEN
+  dive into how to set it up correctly.
+
+- User says "secrets management with .env files" -> First ask: what's the right secrets
+  architecture for your deployment target? Don't just fix the .env approach — recommend
+  the best approach from scratch.
+
+- User says "should we use Git Flow" -> Pick the best workflow outright. Don't present
+  a balanced comparison — make a call.
+
+**The pattern:** Zoom out before zooming in. Recommend the best tool/approach, justify it
+briefly (2-3 sentences on why alternatives lose), then spend the rest of the analysis on
+how to implement the winner correctly.
+
+If the user's current choice IS the best option, say so — "You're already on the right
+tool. Here's how to use it properly." Don't manufacture doubt.
+
+---
+
+## Step 3: Classify the Topic
+
+Auto-detect which category the topic falls into. This determines which output sections to
+include. The user can override by saying something like "treat this as an ops topic."
+
+### Categories and their signature sections:
+
+**Operational / Infrastructure**
+Topics: dependency management, CI/CD, deployment, monitoring, lockfiles, migrations, DevOps.
+Sections: Placement & Structure, Current State Audit, Cleanup Plan, Maintenance Cadence,
+Commands & Conventions, Do/Don't Table.
+
+**Architecture / Design**
+Topics: system design, data modeling, API design, monorepo structure, framework selection.
+Sections: Trade-off Analysis, Decision Matrix, Recommended Approach, Migration Path,
+Risk Assessment.
+
+**Strategy / Business**
+Topics: pricing, go-to-market, team structure, vendor selection, build-vs-buy.
+Sections: Framework & Mental Model, Options Analysis, Recommendation, Implementation
+Roadmap, Risk Assessment.
+
+**Security / Compliance**
+Topics: auth, permissions, secrets management, audit logging, data privacy.
+Sections: Threat Model, Current Gaps, Hardening Plan, Policy Recommendations,
+Verification Checklist.
+
+**Workflow / Process**
+Topics: team conventions, code review, git workflow, release process, onboarding.
+Sections: Current Pain Points, Proposed Workflow, Team Conventions, Automation
+Opportunities, Rollout Plan.
+
+If the topic spans multiple categories, blend the relevant sections. Don't force-fit.
+
+---
+
+## Step 4: Select Depth Level
+
+Detect depth from the user's phrasing, or default to **Standard**.
+
+| Level        | Trigger Phrases                                   | Scope                                                  |
+|-------------|---------------------------------------------------|--------------------------------------------------------|
+| **Quick**    | "quick take", "80/20", "high-level", "tl;dr"     | ONE clear recommendation with 2-3 supporting reasons. ~400-500 words. No tables, no sub-sections, no action plan — just the answer and why. |
+| **Standard** | (default) "deep dive", "break down", "how should" | 5-8 structured questions answered. Full adaptive sections. Aim for ~2000 words (1500-2500 range). |
+| **Exhaustive** | "exhaustive", "comprehensive", "leave nothing out", "full audit" | Every applicable section, edge cases, exception handling, team policy language, example commands. Aim for ~3500 words (3000+ minimum). |
+
+### Quick depth is fundamentally different
+
+At Quick depth, the user wants a decision, not an analysis. Give them:
+- The recommendation (1 sentence)
+- Why it wins (2-3 bullet points)
+- The one exception where you'd change your mind (1 sentence)
+- What to do next (1-2 sentences)
+
+That's it. No Situation Assessment, no Do/Don't table, no Action Plan sections. Those
+are Standard/Exhaustive features. Quick means the user is in a hurry — respect that by
+being brief and decisive.
+
+---
+
+## Step 5: Deliver the Analysis
+
+Structure the response using the applicable sections from the detected category.
+
+### For Standard and Exhaustive depth:
+
+Every deep dive follows this backbone:
+
+1. **Situation Assessment** — What are we dealing with? Ground this in the user's actual
+   context (repo structure, stack, symptoms they described). Include the premise challenge
+   here — if you're recommending a different approach than what the user assumed, state it
+   upfront with brief justification.
+
+2. **Core Questions Answered** — The 3-8 most important questions for this topic, each
+   answered with ONE clear recommendation. Not "Option A vs Option B" — pick A or B and
+   explain why in 2-3 sentences. The user hired you to make the call.
+
+3. **Category-Specific Sections** — Pull in the relevant sections from the topic category
+   above. Not all sections are required every time — include only the ones that add value.
+
+4. **Do This / Don't Do This** — A crisp reference table. Two columns. Short rows.
+   Focused on the mistakes the user is most likely to make.
+
+5. **Action Plan** — Numbered steps the user can execute immediately. If the topic has a
+   cleanup phase and an ongoing maintenance phase, separate them clearly.
+
+### For Quick depth:
+
+Skip the backbone entirely. Write flowing prose — recommendation, reasoning, exception,
+next step. See the Quick depth section above.
+
+---
+
+## Principles
+
+1. **One answer, not a menu.** The user is asking for your expert opinion. Every question
+   gets ONE recommendation. Briefly note the 1 condition where you'd deviate, then move on.
+   If you find yourself writing "Option A... Option B... Option C..." you're doing it wrong.
+   Pick the best one and own it.
+
+2. **Challenge before optimizing.** Zoom out before zooming in. Make sure the user is
+   solving the right problem with the right tool before spending 2000 words on implementation.
+
+3. **Ground in live docs.** Use `find-docs` to fetch current documentation for any tool
+   or framework mentioned. Training data gets stale; official docs don't.
+
+4. **Be specific to their stack.** If you know they're using Bun, don't give npm advice.
+   If you scanned their repo, reference their actual file names and config.
+
+5. **Focus on what to avoid.** The most valuable part of expert advice is knowing what NOT
+   to do. Every deep dive should surface the common mistakes, anti-patterns, and traps.
+
+6. **Make it actionable.** Every section should leave the user knowing what to DO, not just
+   what to think. Include commands, config snippets, and checklists where applicable.
+
+7. **Respect the depth level.** Quick means ~400-500 words, no structure. Standard means
+   ~2000 words with full structure. Exhaustive means ~3500 words with every section.
+   Don't pad Quick or shortchange Exhaustive.
+
+---
+
+## Edge Cases
+
+- **User provides a vague topic** ("deep dive into my project"): Ask 1-2 clarifying
+  questions before proceeding. Don't guess.
+- **Topic doesn't fit a category**: Use the Operational category as default and adapt.
+- **User overrides category or depth**: Always respect explicit overrides.
+- **find-docs unavailable**: Proceed with training knowledge, but flag areas where the
+  user should verify against current docs.

--- a/claude-code/plugins/skill-stats/.claude-plugin/plugin.json
+++ b/claude-code/plugins/skill-stats/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "skill-stats",
+  "version": "0.1.0",
+  "description": "Telemetry-driven report on Claude Code skill usage. Bundles a PreToolUse hook that logs every Skill invocation to a plugin-owned JSONL file, plus a report generator that surfaces top-used skills, recently-active skills, dormant skills (size + last-touched), and phantom invocations. Uses ${CLAUDE_PLUGIN_DATA} for telemetry storage so it survives plugin updates and never collides with other plugins.",
+  "author": {
+    "name": "Ossie Irondi"
+  },
+  "homepage": "https://github.com/AojdevStudio/agentic-utilities/tree/main/claude-code/plugins/skill-stats",
+  "repository": "https://github.com/AojdevStudio/agentic-utilities",
+  "license": "MIT",
+  "keywords": [
+    "telemetry",
+    "skills",
+    "claude-code",
+    "harness",
+    "introspection",
+    "infrastructure",
+    "dormancy",
+    "pruning"
+  ]
+}

--- a/claude-code/plugins/skill-stats/README.md
+++ b/claude-code/plugins/skill-stats/README.md
@@ -1,0 +1,53 @@
+# skill-stats
+
+Telemetry-driven report on Claude Code skill usage. Tells you which skills you actually use, which ones are gathering dust, and how much disk they cost.
+
+## What it does
+
+When enabled, this plugin:
+
+1. **Bundles a PreToolUse hook** (`hooks/log-skill.ts`) that fires on every `Skill` tool invocation and appends one JSONL event to plugin-owned telemetry. The hook is non-blocking — failures exit silently and never interfere with skill execution.
+2. **Provides a report skill** that reads that telemetry, scans installed skills (`~/.claude/skills/`, `~/.claude/plugins/marketplaces/`), and generates either a human-readable text report or JSON.
+
+## Storage layout
+
+Telemetry lives at `${CLAUDE_PLUGIN_DATA}/events.jsonl` — Claude Code's canonical plugin-scoped data path, which resolves to `~/.claude/plugins/data/skill-stats/events.jsonl` and survives plugin updates. If `CLAUDE_PLUGIN_DATA` is not exported (e.g., when running the report manually outside a plugin context), the script falls back to the same `~/.claude/plugins/data/skill-stats/events.jsonl` path.
+
+The hook never logs tool inputs, file contents, or user prompts. Only:
+
+```json
+{"event":"skill_invocation","skill":"<name>","session_id":"<id>","timestamp":"<iso>"}
+```
+
+## Trigger phrases
+
+Auto-activates when you ask:
+
+- "show me skill stats"
+- "which skills are dormant?"
+- "what skills do I use most?"
+- "skill telemetry"
+- "prune unused skills"
+- "skill usage report"
+
+Or run the report directly:
+
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/report.ts          # text report
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/report.ts --json   # JSON
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/report.ts --days=7
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/report.ts --author=YourName
+```
+
+## Prerequisites
+
+- **Bun** — the hook and report scripts run on Bun (`curl -fsSL https://bun.sh/install | bash`).
+- **Time** — telemetry only covers events captured after install. Expect 3–7 days of normal usage before the report has signal.
+
+## Coexisting with other skill-tracking hooks
+
+Plugin hooks merge with user-level hooks in parallel. If you already maintain your own skill-tracking PreToolUse hook (e.g., a personal `SkillGuard.hook.ts`), this plugin's hook runs alongside it without interfering — they write to different files and never coordinate.
+
+## License
+
+MIT — see repository LICENSE.

--- a/claude-code/plugins/skill-stats/hooks/hooks.json
+++ b/claude-code/plugins/skill-stats/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Logs every Skill tool invocation to plugin-owned telemetry for later reporting.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun ${CLAUDE_PLUGIN_ROOT}/scripts/log-skill.ts",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/claude-code/plugins/skill-stats/scripts/log-skill.ts
+++ b/claude-code/plugins/skill-stats/scripts/log-skill.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env bun
+/**
+ * skill-stats log-skill hook
+ *
+ * Fires on PreToolUse with matcher "Skill". Reads the hook input JSON from
+ * stdin, extracts the skill name from `tool_input.skill`, and appends a
+ * single JSONL event to the plugin's telemetry file.
+ *
+ * Storage path resolution (in priority order):
+ *   1. $CLAUDE_PLUGIN_DATA/events.jsonl          (canonical, plugin-scoped)
+ *   2. $HOME/.claude/plugins/data/skill-stats/events.jsonl  (fallback)
+ *
+ * The hook NEVER blocks skill execution — any error path silently exits 0.
+ * The report generator (scripts/report.ts) reads from the same path.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname } from "node:path";
+
+interface HookInput {
+  tool_name?: string;
+  tool_input?: { skill?: string };
+  session_id?: string;
+  hook_event_name?: string;
+}
+
+function resolveTelemetryPath(): string {
+  const data = process.env.CLAUDE_PLUGIN_DATA;
+  if (data && data.length > 0) return `${data}/events.jsonl`;
+  return `${homedir()}/.claude/plugins/data/skill-stats/events.jsonl`;
+}
+
+async function readStdin(timeoutMs = 1000): Promise<string> {
+  return new Promise((resolve) => {
+    let data = "";
+    const timer = setTimeout(() => resolve(data), timeoutMs);
+    process.stdin.on("data", (chunk) => {
+      data += chunk.toString();
+    });
+    process.stdin.on("end", () => {
+      clearTimeout(timer);
+      resolve(data);
+    });
+    process.stdin.on("error", () => {
+      clearTimeout(timer);
+      resolve("");
+    });
+  });
+}
+
+async function main() {
+  try {
+    const raw = await readStdin();
+    if (!raw) process.exit(0);
+
+    const input: HookInput = JSON.parse(raw);
+    const skill = (input.tool_input?.skill ?? "").trim();
+    if (!skill) process.exit(0);
+
+    const sessionId = input.session_id ?? "no-session";
+    if (sessionId === "smoke" || sessionId === "test") process.exit(0);
+
+    const event = {
+      event: "skill_invocation",
+      skill,
+      session_id: sessionId,
+      timestamp: new Date().toISOString(),
+    };
+
+    const path = resolveTelemetryPath();
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, JSON.stringify(event) + "\n");
+    process.exit(0);
+  } catch {
+    process.exit(0);
+  }
+}
+
+main();

--- a/claude-code/plugins/skill-stats/scripts/report.ts
+++ b/claude-code/plugins/skill-stats/scripts/report.ts
@@ -1,0 +1,543 @@
+#!/usr/bin/env bun
+/**
+ * skill-stats report generator
+ *
+ * Reads plugin-owned telemetry written by hooks/log-skill.ts and produces
+ * either a human-readable text report or machine-readable JSON.
+ *
+ * Telemetry path resolution mirrors log-skill.ts:
+ *   1. $CLAUDE_PLUGIN_DATA/events.jsonl
+ *   2. $HOME/.claude/plugins/data/skill-stats/events.jsonl
+ *
+ * Skill discovery scans the standard Claude Code skill locations:
+ *   - $HOME/.claude/skills/
+ *   - $HOME/.claude/plugins/marketplaces/
+ *
+ * Flags:
+ *   --json              machine-readable JSON
+ *   --days=N            restrict telemetry window to last N days
+ *   --stale=N           custom stale threshold in days (default 30)
+ *   --author=NAME       filter to skills whose SKILL.md frontmatter `authors:`
+ *                       (or `author:`) contains NAME
+ */
+
+import { readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join } from "node:path";
+
+const HOME = homedir();
+const SKILLS_DIRS = [`${HOME}/.claude/skills`, `${HOME}/.claude/plugins/marketplaces`];
+
+function resolveTelemetryPath(): string {
+  const data = process.env.CLAUDE_PLUGIN_DATA;
+  if (data && data.length > 0) return `${data}/events.jsonl`;
+  return `${HOME}/.claude/plugins/data/skill-stats/events.jsonl`;
+}
+
+const TELEMETRY = resolveTelemetryPath();
+const NOW = Date.now();
+const DAY_MS = 86_400_000;
+
+type Installed = {
+  name: string;
+  emoji: string;
+  path: string;
+  source: "user" | "plugin";
+  marketplace?: string;
+  mtime: number;
+  sizeBytes: number;
+  authors: string[];
+};
+
+type Usage = {
+  count: number;
+  firstUsed: number;
+  lastUsed: number;
+  sessions: Set<string>;
+};
+
+const args = process.argv.slice(2);
+const flags = {
+  json: args.includes("--json"),
+  windowDays: parseInt(args.find((a) => a.startsWith("--days="))?.split("=")[1] ?? "0", 10),
+  staleDays: parseInt(args.find((a) => a.startsWith("--stale="))?.split("=")[1] ?? "30", 10),
+  author: args.find((a) => a.startsWith("--author="))?.split("=")[1] ?? null,
+};
+
+function dirSize(dir: string): number {
+  let total = 0;
+  function walk(d: string) {
+    let entries: ReturnType<typeof readdirSync>;
+    try {
+      entries = readdirSync(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const ent of entries) {
+      const full = join(d, ent.name);
+      try {
+        const s = statSync(full);
+        if (s.isFile()) total += s.size;
+        else if (s.isDirectory()) walk(full);
+      } catch {}
+    }
+  }
+  walk(dir);
+  return total;
+}
+
+function parseAuthors(fm: string): string[] {
+  const lines = fm.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^author[s]?\s*:\s*(.*)$/);
+    if (!m) continue;
+    const rest = m[1].trim();
+    if (rest.startsWith("[") && rest.endsWith("]")) {
+      return rest
+        .slice(1, -1)
+        .split(",")
+        .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+        .filter(Boolean);
+    }
+    if (rest) return [rest.replace(/^["']|["']$/g, "")];
+    const out: string[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      const item = lines[j].match(/^\s+-\s+(.*)$/);
+      if (!item) break;
+      out.push(item[1].trim().replace(/^["']|["']$/g, ""));
+    }
+    return out;
+  }
+  return [];
+}
+
+function parseFrontmatter(file: string): { name: string | null; emoji: string; authors: string[] } {
+  try {
+    const text = readFileSync(file, "utf8");
+    const m = text.match(/^---\n([\s\S]*?)\n---/);
+    if (!m) return { name: null, emoji: "", authors: [] };
+    const lines = m[1].split("\n");
+    const nameLine = lines.find((l) => l.startsWith("name:"));
+    const emojiLine = lines.find((l) => l.startsWith("emoji:"));
+    const name = nameLine
+      ? nameLine
+          .replace(/^name:\s*/, "")
+          .trim()
+          .replace(/^["']|["']$/g, "")
+      : null;
+    const emoji = emojiLine
+      ? emojiLine
+          .replace(/^emoji:\s*/, "")
+          .trim()
+          .replace(/^["']|["']$/g, "")
+      : "";
+    return { name, emoji, authors: parseAuthors(m[1]) };
+  } catch {
+    return { name: null, emoji: "", authors: [] };
+  }
+}
+
+function findSkillFiles(root: string, maxDepth: number): string[] {
+  const found: string[] = [];
+  const seen = new Set<string>();
+
+  function walk(dir: string, depth: number) {
+    if (depth > maxDepth) return;
+    let entries: ReturnType<typeof readdirSync>;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const ent of entries) {
+      const full = join(dir, ent.name);
+      let real: string;
+      try {
+        real = realpathSync(full);
+      } catch {
+        continue;
+      }
+      if (seen.has(real)) continue;
+      seen.add(real);
+      if (ent.name === "SKILL.md" && ent.isFile()) {
+        found.push(full);
+        continue;
+      }
+      let isDir = ent.isDirectory();
+      if (ent.isSymbolicLink()) {
+        try {
+          isDir = statSync(full).isDirectory();
+        } catch {
+          isDir = false;
+        }
+      }
+      if (isDir && !ent.name.startsWith(".") && ent.name !== "node_modules") {
+        walk(full, depth + 1);
+      }
+    }
+  }
+
+  walk(root, 0);
+  return found;
+}
+
+function discoverInstalled(): Installed[] {
+  const out: Installed[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const file of findSkillFiles(SKILLS_DIRS[0], 2)) {
+    const fm = parseFrontmatter(file);
+    const name = fm.name ?? basename(dirname(file));
+    const dir = dirname(file);
+    const realDir = realpathSync(dir);
+    if (seenPaths.has(realDir)) continue;
+    seenPaths.add(realDir);
+    const s = statSync(dir);
+    out.push({
+      name,
+      emoji: fm.emoji,
+      path: dir,
+      source: "user",
+      mtime: s.mtimeMs,
+      sizeBytes: dirSize(realDir),
+      authors: fm.authors,
+    });
+  }
+
+  for (const file of findSkillFiles(SKILLS_DIRS[1], 5)) {
+    if (file.includes("/temp_")) continue;
+    const fm = parseFrontmatter(file);
+    const name = fm.name ?? basename(dirname(file));
+    const rel = file.replace(SKILLS_DIRS[1] + "/", "");
+    const marketplace = rel.split("/")[0];
+    const dir = dirname(file);
+    const realDir = realpathSync(dir);
+    if (seenPaths.has(realDir)) continue;
+    seenPaths.add(realDir);
+    const s = statSync(dir);
+    out.push({
+      name,
+      emoji: fm.emoji,
+      path: dir,
+      source: "plugin",
+      marketplace,
+      mtime: s.mtimeMs,
+      sizeBytes: dirSize(realDir),
+      authors: fm.authors,
+    });
+  }
+
+  return out;
+}
+
+function parseTelemetry(): Map<string, Usage> {
+  const usage = new Map<string, Usage>();
+  let raw: string;
+  try {
+    raw = readFileSync(TELEMETRY, "utf8");
+  } catch {
+    return usage;
+  }
+
+  const cutoff = flags.windowDays > 0 ? NOW - flags.windowDays * DAY_MS : 0;
+
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let evt: { event?: string; skill?: string; session_id?: string; timestamp?: string };
+    try {
+      evt = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (evt.event !== "skill_invocation") continue;
+    if (!evt.skill) continue;
+    if (evt.session_id === "smoke" || evt.session_id === "test") continue;
+
+    const ts = evt.timestamp ? new Date(evt.timestamp).getTime() : NaN;
+    if (!Number.isFinite(ts)) continue;
+    if (cutoff && ts < cutoff) continue;
+
+    const name = evt.skill;
+    const u = usage.get(name) ?? ({ count: 0, firstUsed: ts, lastUsed: ts, sessions: new Set<string>() } as Usage);
+    u.count += 1;
+    u.firstUsed = Math.min(u.firstUsed, ts);
+    u.lastUsed = Math.max(u.lastUsed, ts);
+    if (evt.session_id) u.sessions.add(evt.session_id);
+    usage.set(name, u);
+  }
+  return usage;
+}
+
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function matchUsage(installed: Installed[], usage: Map<string, Usage>) {
+  const usageByNorm = new Map<string, { name: string; data: Usage }>();
+  for (const [name, data] of usage) usageByNorm.set(normalize(name), { name, data });
+
+  const seenNames = new Set<string>();
+  const matched: Array<{ skill: Installed; usage: Usage; invokedAs: string; duplicates: number }> = [];
+  const dormant: Installed[] = [];
+  const duplicateCount = new Map<string, number>();
+
+  for (const skill of installed) {
+    const norm = normalize(skill.name);
+    if (seenNames.has(norm)) {
+      duplicateCount.set(norm, (duplicateCount.get(norm) ?? 1) + 1);
+      continue;
+    }
+    seenNames.add(norm);
+    const hit = usageByNorm.get(norm);
+    if (hit) {
+      matched.push({ skill, usage: hit.data, invokedAs: hit.name, duplicates: 0 });
+    } else {
+      dormant.push(skill);
+    }
+  }
+
+  for (const m of matched) {
+    m.duplicates = (duplicateCount.get(normalize(m.skill.name)) ?? 1) - 1;
+  }
+
+  const installedNorms = new Set([...seenNames]);
+  const phantom: Array<{ name: string; data: Usage }> = [];
+  for (const [name, data] of usage) {
+    if (!installedNorms.has(normalize(name))) phantom.push({ name, data });
+  }
+
+  return { matched, dormant, phantom };
+}
+
+function fmtAge(ms: number): string {
+  const days = Math.floor((NOW - ms) / DAY_MS);
+  if (days === 0) return "today";
+  if (days === 1) return "1 day ago";
+  return `${days} days ago`;
+}
+
+function fmtSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}K`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}M`;
+}
+
+function main() {
+  const installed = discoverInstalled();
+  const usage = parseTelemetry();
+  const { matched, dormant, phantom } = matchUsage(installed, usage);
+
+  if (flags.author) {
+    const wanted = flags.author.toLowerCase();
+    const mine = installed.filter((s) => s.authors.some((a) => a.toLowerCase() === wanted));
+    const usageByNorm = new Map<string, Usage>();
+    for (const [n, u] of usage) usageByNorm.set(normalize(n), u);
+
+    if (flags.json) {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            generated_at: new Date(NOW).toISOString(),
+            telemetry_path: TELEMETRY,
+            author: flags.author,
+            count: mine.length,
+            skills: mine.map((s) => {
+              const u = usageByNorm.get(normalize(s.name));
+              return {
+                name: s.name,
+                emoji: s.emoji,
+                source: s.source,
+                marketplace: s.marketplace,
+                size_bytes: s.sizeBytes,
+                authors: s.authors,
+                count: u?.count ?? 0,
+                last_used: u ? new Date(u.lastUsed).toISOString() : null,
+                sessions: u?.sessions.size ?? 0,
+              };
+            }),
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+      return;
+    }
+
+    process.stdout.write("╔══════════════════════════════════════════════════════════════╗\n");
+    process.stdout.write(`║  Skills authored by ${flags.author.padEnd(41)} ║\n`);
+    process.stdout.write("╚══════════════════════════════════════════════════════════════╝\n");
+    process.stdout.write(`Total authored:  ${mine.length}\n`);
+    const totalSize = mine.reduce((a, b) => a + b.sizeBytes, 0);
+    process.stdout.write(`Total disk:      ${fmtSize(totalSize)}\n`);
+    const used = mine.filter((s) => usageByNorm.has(normalize(s.name)));
+    process.stdout.write(`Used:            ${used.length}    Dormant: ${mine.length - used.length}\n\n`);
+
+    const rows = mine
+      .map((s) => ({ s, u: usageByNorm.get(normalize(s.name)) }))
+      .sort((a, b) => (b.u?.count ?? 0) - (a.u?.count ?? 0));
+
+    process.stdout.write(
+      `  ${"name".padEnd(32)}  ${"count".padStart(5)}  ${"sessions".padStart(8)}  ${"last used".padEnd(14)}  size\n`,
+    );
+    process.stdout.write("  " + "─".repeat(76) + "\n");
+    for (const { s, u } of rows) {
+      const emoji = s.emoji ? `${s.emoji} ` : "  ";
+      const last = u ? fmtAge(u.lastUsed) : "—";
+      process.stdout.write(
+        `  ${emoji}${s.name.padEnd(30)}  ${(u?.count ?? 0).toString().padStart(5)}  ${(u?.sessions.size ?? 0).toString().padStart(8)}  ${last.padEnd(14)}  ${fmtSize(s.sizeBytes)}\n`,
+      );
+    }
+    return;
+  }
+
+  if (flags.json) {
+    process.stdout.write(
+      JSON.stringify(
+        {
+          generated_at: new Date(NOW).toISOString(),
+          telemetry_path: TELEMETRY,
+          window_days: flags.windowDays || "all",
+          totals: {
+            installed: installed.length,
+            matched: matched.length,
+            dormant: dormant.length,
+            phantom: phantom.length,
+            total_invocations: [...usage.values()].reduce((a, b) => a + b.count, 0),
+          },
+          matched: matched.map((m) => ({
+            name: m.skill.name,
+            emoji: m.skill.emoji,
+            invoked_as: m.invokedAs,
+            count: m.usage.count,
+            first_used: new Date(m.usage.firstUsed).toISOString(),
+            last_used: new Date(m.usage.lastUsed).toISOString(),
+            sessions: m.usage.sessions.size,
+            source: m.skill.source,
+            size_bytes: m.skill.sizeBytes,
+            authors: m.skill.authors,
+          })),
+          dormant: dormant.map((s) => ({
+            name: s.name,
+            emoji: s.emoji,
+            source: s.source,
+            marketplace: s.marketplace,
+            mtime: new Date(s.mtime).toISOString(),
+            size_bytes: s.sizeBytes,
+            authors: s.authors,
+          })),
+          phantom: phantom.map((p) => ({
+            name: p.name,
+            count: p.data.count,
+            last_used: new Date(p.data.lastUsed).toISOString(),
+          })),
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return;
+  }
+
+  const totalInvocations = [...usage.values()].reduce((a, b) => a + b.count, 0);
+
+  process.stdout.write("╔══════════════════════════════════════════════════════════════╗\n");
+  process.stdout.write("║  Claude Code Skill Telemetry — Usage & Dormancy Report       ║\n");
+  process.stdout.write("╚══════════════════════════════════════════════════════════════╝\n");
+  process.stdout.write(`Generated:        ${new Date(NOW).toISOString()}\n`);
+  process.stdout.write(`Telemetry file:   ${TELEMETRY}\n`);
+  process.stdout.write(
+    `Window:           ${flags.windowDays > 0 ? `last ${flags.windowDays} days` : "all telemetry"}\n`,
+  );
+
+  if (totalInvocations > 0) {
+    const earliest = Math.min(...[...usage.values()].map((u) => u.firstUsed));
+    const latest = Math.max(...[...usage.values()].map((u) => u.lastUsed));
+    process.stdout.write(
+      `Telemetry span:   ${new Date(earliest).toISOString().slice(0, 10)} → ${new Date(latest).toISOString().slice(0, 10)}\n`,
+    );
+  } else {
+    process.stdout.write(`Telemetry span:   (no events recorded yet — hook will populate as skills are invoked)\n`);
+  }
+
+  process.stdout.write(
+    `Installed skills: ${installed.length} (${installed.filter((s) => s.source === "user").length} user, ${installed.filter((s) => s.source === "plugin").length} plugin)\n`,
+  );
+  process.stdout.write(`Total invocations: ${totalInvocations}\n`);
+  process.stdout.write(`Distinct used:    ${matched.length}\n`);
+  process.stdout.write(`Dormant:          ${dormant.length}  (installed, never invoked)\n`);
+  process.stdout.write(`Phantom:          ${phantom.length}  (invoked but no SKILL.md found)\n\n`);
+
+  const emojiSlot = (e: string) => (e ? `${e} ` : "  ");
+
+  process.stdout.write("─── TOP 20 MOST USED ──────────────────────────────────────────\n");
+  const sortedMatched = [...matched].sort((a, b) => b.usage.count - a.usage.count);
+  if (sortedMatched.length === 0) process.stdout.write("  (none yet)\n");
+  for (const m of sortedMatched.slice(0, 20)) {
+    const pct = totalInvocations > 0 ? ((m.usage.count / totalInvocations) * 100).toFixed(1) : "0.0";
+    process.stdout.write(
+      `  ${m.usage.count.toString().padStart(4)}  ${pct.padStart(5)}%  ${emojiSlot(m.skill.emoji)} ${m.skill.name.padEnd(26)}  last: ${fmtAge(m.usage.lastUsed)}\n`,
+    );
+  }
+  process.stdout.write("\n");
+
+  process.stdout.write("─── RECENTLY ACTIVE (last 7 days) ─────────────────────────────\n");
+  const recent = sortedMatched.filter((m) => NOW - m.usage.lastUsed < 7 * DAY_MS);
+  if (recent.length === 0) process.stdout.write("  (none)\n");
+  for (const m of recent) {
+    process.stdout.write(
+      `  ${emojiSlot(m.skill.emoji)} ${m.skill.name.padEnd(30)}  ${m.usage.count}× over ${m.usage.sessions.size} sessions\n`,
+    );
+  }
+  process.stdout.write("\n");
+
+  process.stdout.write(`─── STALE (used but not in last ${flags.staleDays} days) ──────────────────\n`);
+  const stale = sortedMatched.filter((m) => NOW - m.usage.lastUsed > flags.staleDays * DAY_MS);
+  if (stale.length === 0) process.stdout.write("  (none)\n");
+  for (const m of stale) {
+    process.stdout.write(
+      `  ${emojiSlot(m.skill.emoji)} ${m.skill.name.padEnd(30)}  ${m.usage.count}× — last ${fmtAge(m.usage.lastUsed)}\n`,
+    );
+  }
+  process.stdout.write("\n");
+
+  process.stdout.write("─── DORMANT (installed, never invoked) ────────────────────────\n");
+  const sortedDormant = [...dormant].sort((a, b) => b.sizeBytes - a.sizeBytes);
+  process.stdout.write(
+    `  Total: ${dormant.length} skills, ${fmtSize(dormant.reduce((a, b) => a + b.sizeBytes, 0))} on disk\n\n`,
+  );
+  process.stdout.write(
+    `  ${"name".padEnd(32)}  ${"source".padEnd(8)}  ${"size".padStart(8)}  ${"last touched".padEnd(14)}\n`,
+  );
+  process.stdout.write("  " + "─".repeat(72) + "\n");
+  for (const s of sortedDormant) {
+    const src = s.source === "plugin" ? `plugin:${s.marketplace?.slice(0, 12) ?? ""}` : "user";
+    process.stdout.write(
+      `  ${emojiSlot(s.emoji)} ${s.name.padEnd(30)}  ${src.padEnd(8)}  ${fmtSize(s.sizeBytes).padStart(8)}  ${fmtAge(s.mtime)}\n`,
+    );
+  }
+  process.stdout.write("\n");
+
+  if (phantom.length > 0) {
+    process.stdout.write("─── PHANTOM (invoked but no SKILL.md found) ───────────────────\n");
+    process.stdout.write("  These names appear in telemetry but don't match any installed skill.\n");
+    process.stdout.write("  Likely plugin-namespaced skills or uninstalled skills:\n\n");
+    const sortedPhantom = [...phantom].sort((a, b) => b.data.count - a.data.count);
+    for (const p of sortedPhantom) {
+      process.stdout.write(
+        `  ${p.data.count.toString().padStart(4)}  ${p.name.padEnd(32)}  last: ${fmtAge(p.data.lastUsed)}\n`,
+      );
+    }
+    process.stdout.write("\n");
+  }
+
+  process.stdout.write("─── PRUNING CANDIDATES ─────────────────────────────────────────\n");
+  const pruneByBytes = sortedDormant.slice(0, 5).reduce((a, b) => a + b.sizeBytes, 0);
+  process.stdout.write(`  Top 5 dormant by disk size = ${fmtSize(pruneByBytes)}\n`);
+  process.stdout.write(`  All dormant disk total     = ${fmtSize(dormant.reduce((a, b) => a + b.sizeBytes, 0))}\n`);
+  process.stdout.write(
+    `  Reminder: dormant != deletable — telemetry only goes back as far as the hook has been collecting.\n\n`,
+  );
+  process.stdout.write("Flags:  --json  --days=N  --stale=N  --author=NAME\n");
+}
+
+main();

--- a/claude-code/plugins/skill-stats/skills/skill-stats/SKILL.md
+++ b/claude-code/plugins/skill-stats/skills/skill-stats/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: skill-stats
+description: "Report Claude Code skill-usage telemetry — top used, recently active, dormant skills, plus on-disk size. USE WHEN: skill stats, skill usage, dormant skills, which skills do I use, prune skills, skill telemetry, what skills are dormant, most popular skills."
+---
+
+# skill-stats — Usage & Dormancy Report
+
+Aggregates skill-invocation telemetry written by this plugin's bundled PreToolUse hook (`hooks/log-skill.ts`) and cross-references against the on-disk skill catalog at `~/.claude/skills/` and `~/.claude/plugins/marketplaces/`.
+
+## How it works
+
+1. **Hook (auto-installed):** When this plugin is enabled, a PreToolUse hook fires on every `Skill` tool invocation and appends one JSONL event to the plugin's telemetry file (`${CLAUDE_PLUGIN_DATA}/events.jsonl`, falling back to `~/.claude/plugins/data/skill-stats/events.jsonl`). The hook is non-blocking — any failure exits silently and never interferes with skill execution.
+2. **Report (this skill):** The reporting script reads that telemetry, scans installed skills, and produces a usage report.
+
+**First-run note:** Right after install, telemetry is empty. Use the plugin for a few days/sessions to accumulate data, then run the report.
+
+## How to use
+
+Run the underlying script directly:
+
+```bash
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/report.ts                    # full text report
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/report.ts --json              # machine-readable JSON
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/report.ts --days=7            # restrict to last N days
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/report.ts --stale=14          # custom stale threshold
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/report.ts --author=NAME       # filter by SKILL.md frontmatter `authors:`
+```
+
+The `--author=NAME` view reads the `authors:` field from each SKILL.md frontmatter and lists matching skills with their usage counts, session counts, last-used age, and on-disk size. Dormant authored skills surface with `count = 0` for easy pruning decisions.
+
+When invoking this skill in chat, run the JSON form, parse it, and present a clean markdown table with these sections:
+
+1. **Headline** — installed total, distinct used, dormant, phantom counts; telemetry window
+2. **Top 15 most used** — skill name, count, % of total, last used
+3. **Dormant (top 20 by disk size)** — skill name, source (user/plugin), size, last touched
+4. **Phantom** — names appearing in telemetry but not on disk (usually plugin-namespaced commands or uninstalled skills)
+5. **Pruning candidates** — total disk that would be reclaimed by removing all dormant skills
+
+## Caveats to surface in the report
+
+- The telemetry window only goes back to when the plugin's hook started recording. A "dormant" skill may simply be one used before the plugin was installed.
+- Plugin-namespaced names like `codex:rescue` show as phantom because they are slash-commands, not standalone SKILL.md files. They are real and used, just stored differently.
+- Symlinked skill directories are followed by realpath so the same physical directory linked under multiple paths is counted once.
+
+## Snapshot history
+
+Snapshots are useful for trend comparison. To save one:
+
+```bash
+mkdir -p "${CLAUDE_PLUGIN_DATA}/snapshots"
+bun ${CLAUDE_PLUGIN_ROOT}/scripts/report.ts --json > "${CLAUDE_PLUGIN_DATA}/snapshots/skill-stats-$(date +%Y%m%d).json"
+```
+
+If `${CLAUDE_PLUGIN_DATA}` is not set in your shell, fall back to `~/.claude/plugins/data/skill-stats/snapshots/`.
+
+## Telemetry schema
+
+Each line of `events.jsonl` is a self-contained JSON object:
+
+```json
+{"event":"skill_invocation","skill":"deep-dive","session_id":"abc123","timestamp":"2026-05-01T20:00:00.000Z"}
+```
+
+The hook never logs tool inputs, file paths, or user prompts — only the skill name, session ID, and timestamp. Sessions named `smoke` or `test` are excluded.

--- a/skills/bambu-slicer/SKILL.md
+++ b/skills/bambu-slicer/SKILL.md
@@ -122,9 +122,36 @@ For the full quality and filament tables, read `references/profiles.md`.
 
 Output location: default to `/tmp/` for quick prints, or the user's configured output directory. Do not write generated 3MF/G-code into committed skill files.
 
-### 4. Multi-object plate arrangement
+### 4. Multi-object plate arrangement and stacking
 
-When the user has multiple STLs to print at once, combine them on one plate:
+When the user has multiple parts to print, **pick the densest packing the geometry allows** before falling back to separate plates. Three patterns, in priority order:
+
+**Pattern A — Vertical stack (parts physically on top of each other).** Use when parts have flat tops AND flat bottoms AND the upper bottom fits within the lower top. The previous part's top surface acts as the bed for the next. Right answer for repeated drawer/bin/lid/tray geometries.
+
+Bambu Studio workflow (CLI cannot do this today — it is a slicer-UI operation):
+
+1. Drag all stackable parts onto a single plate.
+2. Select all → right-click → **Merge** (formerly "Assemble"). Each object becomes a "part" of one assembly. Bambu Studio only allows Z-axis movement on parts, not standalone objects.
+3. Alt+Click (or use the object list) to select each part.
+4. Move tool → set Z to `part_height × index`. Three identical 25 mm drawers stacked: Z = 0, 25, 50.
+5. Slice as normal. The slicer treats the assembly as one tall object with correct layer transitions.
+
+Geometric requirements:
+
+- Flat top on lower part; flat bottom on upper part.
+- Upper part's footprint ⊆ lower part's top (no overhang).
+- Total stacked height ≤ printer Z range (e.g. 256 mm on the P2S).
+- Same filament across the stack.
+
+**Pattern B — Sequential print-by-object (parts side-by-side, one finishes before the next starts).** Use when parts won't vertically stack but are short enough that the head can clear already-printed neighbours. Failure-isolating: one falls off, the rest continue.
+
+Bambu Studio workflow:
+
+1. Place parts on one plate with ≥ `extruder_clearance_max_radius` (~67 mm on Bambu) XY spacing.
+2. Process settings → **Special mode** → Print Schedule: **By Object**.
+3. First-printed objects must have height < `extruder_clearance_height_to_rod` (~25 mm typical) unless they print last.
+
+**Pattern C — Multi-object same-layer plate (default, what the CLI does today).** All parts print together layer-by-layer with travel between them.
 
 ```bash
 bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" \
@@ -132,7 +159,7 @@ bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" \
   --output combined-plate.3mf
 ```
 
-The slicer auto-arranges and auto-orients all objects. Use this for batch printing. See `references/gotchas.md` for bed-margin caveats.
+The slicer auto-arranges and auto-orients all objects. See `references/gotchas.md` for bed-margin caveats and the identical-plate stacking detection rule.
 
 ### 5. Printer control with Bambu MCP
 
@@ -168,12 +195,16 @@ When the user wants to maximize a print session:
 
 ```text
 User wants to 3D print something
-├── Has specific STL file(s)?       → Slice
-├── Wants something custom?         → Design with OpenSCAD
-├── Wants to browse for a model?    → MakerWorld with agent-browser
-├── Multiple things to print?       → Multi-object plate
-├── Asking about printer state?     → Bambu MCP printer control
-└── "Print night" / batch session?  → Batch workflow
+├── Has specific STL file(s)?            → Slice
+├── Wants something custom?              → Design with OpenSCAD
+├── Wants to browse for a model?         → MakerWorld with agent-browser
+├── Multiple things to print?
+│   ├── Repeated flat-topped parts?      → Vertical stack, Pattern A (Section 4)
+│   ├── Short parts that won't stack?    → Sequential by-object, Pattern B (Section 4)
+│   └── Otherwise                        → Multi-object plate, Pattern C (Section 4)
+├── Multi-plate 3MF handed in?           → Identical-plate check (gotchas) → stack if eligible
+├── Asking about printer state?          → Bambu MCP printer control
+└── "Print night" / batch session?       → Batch workflow
 ```
 
 ## Technical notes

--- a/skills/bambu-slicer/SKILL.md
+++ b/skills/bambu-slicer/SKILL.md
@@ -36,7 +36,8 @@ Before slicing anything, verify setup once:
 
 3. OrcaSlicer installed at the configured path. Default: `/Applications/OrcaSlicer.app/Contents/MacOS/OrcaSlicer`; override with `ORCA_CLI_PATH`.
 4. Bambu Studio installed. The CLI patches its profile JSONs at slice time; Bambu Studio does not need to be running, but profiles must exist on disk.
-5. Optional local config exists outside committed files, for example `.bambu-slicer.local.md` or `~/.config/bambu-slicer/local.md`, with placeholders resolved by the user. The CLI itself reads environment variables: `ORCA_CLI_PATH`, `BAMBU_PROFILE_BASE`, and `BAMBU_MACHINE_PROFILE`.
+5. Optional local config exists outside committed files, for example `.bambu-slicer.local.md` or `~/.config/bambu-slicer/local.md`, with placeholders resolved by the user. The CLI itself reads environment variables: `ORCA_CLI_PATH`, `BAMBU_PROFILE_BASE`, `BAMBU_MACHINE_PROFILE`, `BAMBU_OUTPUT_DIR`, and `BAMBU_DEFAULT_FILAMENT`.
+6. Generated print artifacts default to a temp generated-artifact directory. Set `BAMBU_OUTPUT_DIR` to the user's preferred generated-artifact directory when needed. Do **not** save generated STL/3MF/G-code files into `~/Downloads` unless the user explicitly asks for a one-off there.
 
 If any step fails, surface a clear error before attempting to slice.
 
@@ -103,16 +104,17 @@ CLI usage:
 
 ```bash
 # Single file, default settings: 0.20 mm Standard, Bambu PLA Basic
-bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" --input model.stl --output model.3mf
+# Output defaults to a generated-artifact temp directory unless BAMBU_OUTPUT_DIR is set
+bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" --input model.stl
 
 # Custom quality
-bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" --input model.stl --output model.3mf --quality 0.12
+bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" --input model.stl --quality 0.12
 
 # Custom filament
-bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" --input model.stl --output model.3mf --filament "Bambu PETG Basic"
+bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" --input model.stl --filament "Bambu PETG Basic"
 
 # Multiple objects on one plate, space-separated
-bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" --input "box.stl cylinder.stl hook.stl" --output plate.3mf
+bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" --input "box.stl cylinder.stl hook.stl"
 
 # List available profiles
 bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" --list-profiles
@@ -120,7 +122,17 @@ bun run "$BAMBU_SLICER_CLI_DIR/cli.ts" --list-profiles
 
 For the full quality and filament tables, read `references/profiles.md`.
 
-Output location: default to `/tmp/` for quick prints, or the user's configured output directory. Do not write generated 3MF/G-code into committed skill files.
+Output location: default to a generated-artifact temp directory. Use `BAMBU_OUTPUT_DIR` when the user explicitly chooses another generated-artifact directory. Do not write generated 3MF/G-code into `~/Downloads` or committed skill files.
+
+### 3a. Filament and AMS selection
+
+Do not treat the slicer profile color as the user's loaded filament color. Bambu/Orca profile JSONs often carry a default display color (for example orange-ish PLA), which is not an AMS inventory check.
+
+Before choosing a filament profile:
+
+1. If `bambu-printer` MCP AMS tools are available, query the printer/AMS and pick the loaded spool that matches the required material. Prefer exact material + brand (`Bambu PLA Basic`, `Bambu PETG Basic`) over color. Report the selected tray/material/color.
+2. If AMS tools are unavailable in this Pi session, preserve the source 3MF filament/material when possible. Otherwise ask the user which loaded material/profile to use before slicing multi-material or color-sensitive prints.
+3. For separable vertical stacks, require an incompatible release interface: PLA parts → PETG interface; PETG parts → PLA interface. Verify the AMS has both materials before generating a print-ready file.
 
 ### 4. Multi-object plate arrangement and stacking
 

--- a/skills/bambu-slicer/references/gotchas.md
+++ b/skills/bambu-slicer/references/gotchas.md
@@ -46,9 +46,15 @@ Failure modes to flag before stacking:
 - Lower part has any top-surface overhang or curvature → Pattern A will not bond cleanly. Fall back to Pattern B (sequential by-object) or separate plates.
 - Upper part footprint exceeds lower top → overhang on the print, abort the stack offer.
 - Combined stack height > printer Z range → split into smaller stacks.
-- Different filaments per layer → requires AMS swap or pause-resume; not in scope for the simple stack offer.
+- Different filaments per layer → requires AMS swap or pause-resume. For separable stacks this is expected: use an incompatible release interface and verify AMS materials first.
 
 Tooling status: pre-composing a stacked STL from N inputs is a candidate CLI enhancement (`--stack-z` taking N inputs and writing a Z-offset assembly STL). Today the operation is performed in Bambu Studio's UI via Merge → Move on Z.
+
+## Separable vertical stacks need a release interface
+
+When the user asks to "stack" duplicate parts, do **not** assume same-material contact is acceptable. Same-material vertical stacks can fuse into one part. For separable PLA stacks, insert a one-layer PETG release/interface sheet at the contact plane and assign it to a PETG filament; for PETG parts, use PLA as the incompatible release material.
+
+Failure mode: same-filament Pattern A stack bonds at the flat interface. Root cause: the upper first layer is printed directly onto the previous part's top surface. Fix: make the stack an assembly with bottom part = model filament, one release layer = incompatible filament, top part = model filament, then preview the interface layer before printing. Save the generated 3MF under the configured generated-artifact output directory, not Downloads. Why it matters: "stacked" usually means batched but separable, not fused.
 
 ## Two-up plates when geometry permits
 

--- a/skills/bambu-slicer/references/gotchas.md
+++ b/skills/bambu-slicer/references/gotchas.md
@@ -28,6 +28,28 @@ The CLI doesn't yet have `--infill` / `--walls` flags. Until it does, override v
 
 When the user opens an OrcaSlicer-produced 3MF in Bambu Studio, BS will show an info dialog mapping a few keys (`ensure_vertical_shell_thickness` → `ensure_all`, `rectilinear` ironing → `zig-zag`, etc.). This is harmless schema drift — print parameters are preserved. Tell the user to click OK and proceed.
 
+## Detect multi-plate 3MFs with identical parts and offer vertical stacking
+
+When the user hands a `.3mf` with multiple plates, **inspect the part files before slicing each plate separately**. If two or more plates are the same flat-topped functional part (drawers, lids, bins, plates), default to offering the Pattern A vertical stack from `SKILL.md` Section 4 instead of N separate prints.
+
+```bash
+unzip -l source.3mf | grep '3D/Objects/'
+mkdir -p /tmp/3mf-inspect && cd /tmp/3mf-inspect && unzip -qo source.3mf
+ls -la 3D/Objects/         # equal byte sizes are a strong identical-part signal
+cksum  3D/Objects/*.model  # confirm geometric equality
+```
+
+Why it matters: a 4-plate organizer download where plates 2 and 3 are the same drawer collapses to a single 1- or 2-plate print job. That's N-1 fewer bed preps and N-1 fewer first-layer-failure risk windows. The user wants this — make sure to surface it before queueing the original separate plates.
+
+Failure modes to flag before stacking:
+
+- Lower part has any top-surface overhang or curvature → Pattern A will not bond cleanly. Fall back to Pattern B (sequential by-object) or separate plates.
+- Upper part footprint exceeds lower top → overhang on the print, abort the stack offer.
+- Combined stack height > printer Z range → split into smaller stacks.
+- Different filaments per layer → requires AMS swap or pause-resume; not in scope for the simple stack offer.
+
+Tooling status: pre-composing a stacked STL from N inputs is a candidate CLI enhancement (`--stack-z` taking N inputs and writing a Z-offset assembly STL). Today the operation is performed in Bambu Studio's UI via Merge → Move on Z.
+
 ## Two-up plates when geometry permits
 
 After confirming a single copy fits the bed with margin, **proactively offer a 2-up (or N-up) pre-arranged 3MF** — most users like amortizing bed prep across copies. Pass the same STL multiple times to the CLI:

--- a/skills/bambu-slicer/references/profiles.md
+++ b/skills/bambu-slicer/references/profiles.md
@@ -1,6 +1,6 @@
 # Profile Reference
 
-Default profile names used by the bundled CLI, all targeting a Bambu Lab P2S with a 0.4 mm nozzle. Override via `BAMBU_MACHINE_PROFILE` and the maps in `scripts/cli/profiles.ts` for other Bambu printers.
+Default profile names used by the bundled CLI, all targeting a Bambu Lab P2S with a 0.4 mm nozzle. Override via `BAMBU_MACHINE_PROFILE` and the maps in `scripts/cli/profiles.ts` for other Bambu printers. Generated output defaults to a temp generated-artifact directory; override with `BAMBU_OUTPUT_DIR` for a user-chosen generated-artifact directory.
 
 ## Quality profiles (`--quality`, 0.4 mm nozzle)
 
@@ -16,11 +16,15 @@ Default profile names used by the bundled CLI, all targeting a Bambu Lab P2S wit
 
 | Name | Material | Notes |
 |------|----------|-------|
-| Bambu PLA Basic | PLA (default) | General purpose |
+| Bambu PLA Basic | PLA (default, unless `BAMBU_DEFAULT_FILAMENT` is set) | General purpose. Profile color is not AMS truth. |
 | Bambu PLA Matte | PLA | Nice surface finish |
 | Bambu PETG Basic | PETG | Heat/moisture resistant |
 | Generic PLA | PLA | Third-party PLA |
 | Generic PETG | PETG | Third-party PETG |
+
+## AMS and profile color caveat
+
+The CLI loads filament *profiles*; it does not query the printer AMS by itself. The orange-ish color seen in generated 3MFs comes from Bambu/Orca profile metadata, not from a live spool lookup. When `bambu-printer` MCP AMS tools are available, query AMS first and choose the profile that matches the loaded material. When they are unavailable, preserve the source 3MF material/profile or ask the user.
 
 ## Adding new profiles
 

--- a/skills/bambu-slicer/scripts/cli/cli.ts
+++ b/skills/bambu-slicer/scripts/cli/cli.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env bun
 
-import { resolve } from "node:path";
+import { existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, extname, join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { listProfiles, resolveProfiles } from "./profiles.js";
 import { runSlicer } from "./slicer.js";
+
+const DEFAULT_OUTPUT_DIR = process.env.BAMBU_OUTPUT_DIR || join(tmpdir(), "bambu-slicer-generated");
+const DEFAULT_FILAMENT = process.env.BAMBU_DEFAULT_FILAMENT || "Bambu PLA Basic";
 
 const { values } = parseArgs({
   args: Bun.argv.slice(2),
@@ -11,11 +16,29 @@ const { values } = parseArgs({
     input: { type: "string" },
     output: { type: "string" },
     quality: { type: "string", default: "0.20" },
-    filament: { type: "string", default: "Bambu PLA Basic" },
+    filament: { type: "string", default: DEFAULT_FILAMENT },
     "list-profiles": { type: "boolean", default: false },
   },
   strict: true,
 });
+
+function timestamp(): string {
+  return new Date()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+}
+
+function defaultOutputFor(inputFiles: string[]): string {
+  mkdirSync(DEFAULT_OUTPUT_DIR, { recursive: true });
+  const stem =
+    inputFiles.length === 1
+      ? basename(inputFiles[0], extname(inputFiles[0])).replace(/[^A-Za-z0-9._-]+/g, "_")
+      : `combined-${inputFiles.length}-objects`;
+  const candidate = join(DEFAULT_OUTPUT_DIR, `${stem}.3mf`);
+  if (!existsSync(candidate)) return candidate;
+  return join(DEFAULT_OUTPUT_DIR, `${stem}-${timestamp()}.3mf`);
+}
 
 if (values["list-profiles"]) {
   const { qualities, filaments } = listProfiles();
@@ -26,9 +49,10 @@ if (values["list-profiles"]) {
   process.exit(0);
 }
 
-if (!values.input || !values.output) {
-  console.error('Usage: bun run cli.ts --input <stl> --output <3mf> [--quality 0.20] [--filament "Bambu PLA Basic"]');
+if (!values.input) {
+  console.error('Usage: bun run cli.ts --input <stl> [--output <3mf>] [--quality 0.20] [--filament "Bambu PLA Basic"]');
   console.error("       bun run cli.ts --list-profiles");
+  console.error(`       default output dir: ${DEFAULT_OUTPUT_DIR}`);
   process.exit(1);
 }
 
@@ -38,7 +62,7 @@ const inputFiles = values.input
   .split(/\s+/)
   .filter(Boolean)
   .map((f) => resolve(f));
-const outputFile = resolve(values.output);
+const outputFile = resolve(values.output || defaultOutputFor(inputFiles));
 const profiles = resolveProfiles({
   quality: values.quality!,
   filament: values.filament!,

--- a/skills/harness-audit/SKILL.md
+++ b/skills/harness-audit/SKILL.md
@@ -75,7 +75,7 @@ Use this overlay when the user mentions Symphony, ticket-level orchestration, un
 
 Score the overlay separately using `references/symphony-readiness.md`:
 
-1. **`WORKFLOW.md` contract** — repo-local orchestrator contract with tracker states, workspace hooks, agent settings, and ticket lifecycle prompt.
+1. **`WORKFLOW.md` contract** — repo-local orchestrator contract with tracker states, live tracker preflight, workspace hooks, agent settings, and ticket lifecycle prompt.
 2. **Disposable workspace bootstrap** — fresh clone/workspace can install dependencies, prepare services, and clean up without hidden local state.
 3. **One-command validate loop** — stable command for the meaningful quality gate.
 4. **Agent-visible app validation** — app/browser/log/test path an agent can drive and inspect.
@@ -129,7 +129,7 @@ For Symphony modes, additionally return:
 
 - 9-item Symphony readiness overlay scorecard.
 - Symphony readiness verdict: `Ready`, `Close`, or `Not ready`.
-- Minimum blockers before unattended orchestration.
+- Minimum blockers before unattended orchestration, including missing live tracker preflight when Linear/Symphony is in scope.
 - One recommended smoke-ticket eval shape for this repo.
 
 Keep the baseline report under about 1500 words. For Symphony modes, keep the combined report under about 2200 words unless the user asks for depth. Do not pad.

--- a/skills/harness-audit/SKILL.md
+++ b/skills/harness-audit/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: harness-audit
-description: Audit a repository for autonomous-agent harness readiness across cold-start docs, rules, lint, hooks, tests, PR review automation, repo skills, and garbage-collection cadence. Use for "harness audit", "agent-ready repo", "harness readiness", "make this repo agent-friendly", "harness gaps", or surgical fixes for top harness gaps.
+description: Audit a repository for autonomous-agent harness readiness and Symphony-style unattended ticket execution readiness across cold-start docs, rules, lint, hooks, tests, PR automation, repo skills, garbage-collection cadence, workflow contracts, evidence, observability, and smoke-ticket evals. Use for "harness audit", "agent-ready repo", "harness readiness", "make this repo agent-friendly", "Symphony readiness", "prepare this repo for Symphony", "ticket-level agent automation", or surgical fixes for top harness gaps.
 ---
 
 # Harness Audit
 
-Audit a codebase against an 8-artifact framework for how well-equipped it is for autonomous AI agents to do end-to-end implementation work. Optionally apply surgical fixes for the highest-leverage gaps.
+Audit a codebase against a baseline 8-artifact framework for how well-equipped it is for autonomous AI agents to do end-to-end implementation work. When asked for Symphony readiness, add the unattended ticket-execution overlay: workflow contract, disposable workspace bootstrap, validation/evidence, ticket lifecycle, observability, safety, and smoke-ticket eval. Optionally apply surgical fixes for the highest-leverage gaps.
 
 Framework provenance: Ryan Lopopolo's "Harness Engineering" talk (OpenAI, AI Engineer London 2025). Core thesis: **code is cheap; scarce resources are human time, attention, and model context window.** Codebases that surface the right context to agents at the right time produce more shippable work per human hour.
 
@@ -14,9 +14,49 @@ Framework provenance: Ryan Lopopolo's "Harness Engineering" talk (OpenAI, AI Eng
 - **Repo architecture** — structural design and repo organization. Use that for "how should this repo be laid out?"
 - **Adversarial review** — hunts real bugs in working or near-complete implementations. Use that for "is this code correct?"
 - **Cold-start doc improvement** — narrowly improves `AGENTS.md` / `CLAUDE.md`. This skill covers that plus seven more artifacts.
-- **Harness audit** — asks: *is this repo set up so agents can ship without a human babysitting every step?*
+- **This skill** — asks: *is this repo set up so agents can ship without a human babysitting every step?*
 
-## The 8-artifact stack
+## Mode selection
+
+Default mode is `audit` and is read-only.
+
+Natural-language mapping:
+
+- "harness audit", "agent-ready repo", "harness readiness", "make this repo agent-friendly" → `audit`
+- "audit and fix", "fix harness gaps" → `audit+fix`
+- "Symphony readiness", "prepare this repo for Symphony", "ticket-level agent automation", "unattended ticket execution" → `symphony-readiness`
+- "fix Symphony readiness", "prepare and fix for Symphony" → `audit+fix:symphony`
+- "focus on tests/pre-commit/rules/etc." → `focus:<artifact-name>`
+
+Tie-breaker: default to baseline modes unless the user explicitly says Symphony, ticket-level orchestration, unattended execution, scheduler, tracker workflow, or workflow contract.
+
+Accepted focus names: `cold-start-brief`, `rules-dir`, `lint-messages`, `pre-commit`, `test-suite`, `pr-review`, `repo-skills`, `gc-cadence`, `workflow-contract`, `workspace-bootstrap`, `validate-loop`, `app-validation`, `evidence-protocol`, `ticket-lifecycle`, `observability`, `safety-policy`, `smoke-ticket-eval`.
+
+Numeric aliases:
+
+| Alias | Focus |
+| --- | --- |
+| `focus:1` | `cold-start-brief` |
+| `focus:2` | `rules-dir` |
+| `focus:3` | `lint-messages` |
+| `focus:4` | `pre-commit` |
+| `focus:5` | `test-suite` |
+| `focus:6` | `pr-review` |
+| `focus:7` | `repo-skills` |
+| `focus:8` | `gc-cadence` |
+| `focus:symphony-1` | `workflow-contract` |
+| `focus:symphony-2` | `workspace-bootstrap` |
+| `focus:symphony-3` | `validate-loop` |
+| `focus:symphony-4` | `app-validation` |
+| `focus:symphony-5` | `evidence-protocol` |
+| `focus:symphony-6` | `ticket-lifecycle` |
+| `focus:symphony-7` | `observability` |
+| `focus:symphony-8` | `safety-policy` |
+| `focus:symphony-9` | `smoke-ticket-eval` |
+
+When the user asks for readiness but also asks you to change files, prefer the matching `audit+fix` mode.
+
+## Baseline: the 8-artifact stack
 
 For each artifact, score `✅ Present / ⚠️ Partial / ❌ Missing` with concrete path evidence and a one-line gap.
 
@@ -29,14 +69,32 @@ For each artifact, score `✅ Present / ⚠️ Partial / ❌ Missing` with concr
 7. **Repo-scoped skills/prompts** — `.agents/skills/`, `.pi/skills/`, `.claude/skills/`, `.codex/`, `.pi/prompts/`, or package-scoped resources. Prefer 5-10 deep resources over many shallow ones.
 8. **Garbage-collection cadence** — documented recurring loop that converts agent/PR feedback into permanent rules, lints, docs, or skills.
 
+## Symphony readiness overlay
+
+Use this overlay when the user mentions Symphony, ticket-level orchestration, unattended agents, or preparing repos for an agent scheduler.
+
+Score the overlay separately using `references/symphony-readiness.md`:
+
+1. **`WORKFLOW.md` contract** — repo-local orchestrator contract with tracker states, workspace hooks, agent settings, and ticket lifecycle prompt.
+2. **Disposable workspace bootstrap** — fresh clone/workspace can install dependencies, prepare services, and clean up without hidden local state.
+3. **One-command validate loop** — stable command for the meaningful quality gate.
+4. **Agent-visible app validation** — app/browser/log/test path an agent can drive and inspect.
+5. **Evidence protocol** — documented proof format for reproduction, validation, screenshots/videos/logs, and PR/ticket handoff.
+6. **Ticket/PR lifecycle skill** — repo-scoped workflow for workpad, branch, PR, review comments, human review, rework, and landing.
+7. **Agent-readable observability** — token-efficient CLI/API access to local logs, CI failures, browser console, metrics, or traces.
+8. **Safety/secrets/workspace policy** — env-backed secrets, destructive-command policy, workspace isolation, sandbox/approval posture.
+9. **Smoke-ticket eval** — runnable or documented tiny ticket proving unattended bootstrap → change → validate → evidence → handoff.
+
+Verdict definitions are canonical in `references/symphony-readiness.md`.
+
 ## Workflow
 
 ### Phase 1 — Capture inputs
 
-Inputs may be supplied after `/skill:harness-audit`.
+Inputs may be supplied in natural language with or without an explicit mode label.
 
 - **Target repo path**: default to the current working directory when omitted.
-- **Mode**: `audit` default, `audit+fix`, or `focus:<artifact-name>`.
+- **Mode**: `audit` default, `audit+fix`, `symphony-readiness`, `audit+fix:symphony`, or `focus:<artifact-name>`.
 - **Stack hint**: auto-detect unless supplied.
 
 Do not edit files in `audit` mode. For `audit+fix`, inspect uncommitted changes first and avoid overwriting user work.
@@ -49,9 +107,11 @@ Read whichever exist:
 - `Package.swift`, `*.xcodeproj`, `*.xcworkspace` → Swift.
 - `pyproject.toml`, `requirements.txt`, `setup.py`, `poetry.lock`, `uv.lock`, `Pipfile` → Python.
 - `Cargo.toml` → Rust.
-- `go.mod` → Go/basic generic support.
+- `go.mod` → Go.
 
-Read the matching reference from `references/stack-<stack>.md`. If there is no dedicated stack reference, use `references/audit-prompt.md` plus generic judgment.
+If multiple stack markers exist, audit every major stack that has runtime/build impact. For example, a TypeScript frontend plus Python backend should use both stack references and call out cross-stack bootstrap/validation gaps.
+
+Read the matching reference from `references/stack-<stack>.md`. If there is no dedicated stack reference, use `references/audit-prompt.md` plus generic judgment. For `symphony-readiness` or `audit+fix:symphony`, also read `references/symphony-readiness.md`, `references/evidence-protocol.md`, and `references/smoke-ticket-eval.md`.
 
 ### Phase 3 — Run the audit
 
@@ -59,21 +119,30 @@ Use `references/audit-prompt.md` as the checklist. Execute the audit directly wi
 
 Return:
 
-- 8 artifact scorecards with evidence.
+- 8 baseline artifact scorecards with evidence.
 - Summary scorecard (`X/8 ✅, Y/8 ⚠️, Z/8 ❌`).
 - Top 3 highest-leverage gaps with effort estimate and what each unlocks.
 - Notable strengths.
 - Stack-specific observations.
 
-Keep the report under about 1500 words. Do not pad.
+For Symphony modes, additionally return:
+
+- 9-item Symphony readiness overlay scorecard.
+- Symphony readiness verdict: `Ready`, `Close`, or `Not ready`.
+- Minimum blockers before unattended orchestration.
+- One recommended smoke-ticket eval shape for this repo.
+
+Keep the baseline report under about 1500 words. For Symphony modes, keep the combined report under about 2200 words unless the user asks for depth. Do not pad.
 
 ### Phase 4 — Mode-specific follow-up
 
 - **`audit`**: stop after the report. Do not edit.
-- **`audit+fix`**: fix the top 3 gaps, or fewer if the safe scope is smaller.
-- **`focus:<artifact>`**: skip the full audit and handle only that artifact.
+- **`audit+fix`**: fix the top 3 baseline gaps, or fewer if the safe scope is smaller.
+- **`symphony-readiness`**: audit baseline plus Symphony overlay. Do not edit.
+- **`audit+fix:symphony`**: fix the smallest set of blockers that moves the repo toward unattended ticket execution. Prefer workflow contract, disposable bootstrap, validation/evidence, and smoke eval over cosmetic docs.
+- **`focus:<artifact>`**: read-only by default; skip the full audit and audit only that artifact. For focused edits, use the normal `audit+fix` mode and state the artifact scope in natural language, e.g. `audit+fix, focus pre-commit`.
 
-Use `references/fix-patterns.md` for fix templates.
+Use `references/fix-patterns.md` for fix templates. For Symphony workflow seeding, use `references/workflow-template.md`. For proof requirements, use `references/evidence-protocol.md` and `references/smoke-ticket-eval.md`.
 
 Fix rules:
 
@@ -81,7 +150,7 @@ Fix rules:
 - Verify functionally and show output.
 - Do not commit or push unless the user explicitly requested commits.
 - Do not post to external systems unless explicitly requested.
-- Avoid emojis in committed files unless the repo already uses them.
+- Avoid emojis in committed source/config/docs unless the repo already uses them. Status emojis in audit chat reports are allowed.
 - Use kebab-case filenames unless the repo convention differs.
 - Run fixes sequentially when they touch overlapping files.
 
@@ -102,20 +171,36 @@ Show:
 | Swift / iOS | `references/stack-swift.md` | SwiftLint, swift-format, `xcodebuild` wrapper, GitHub Actions macOS runner |
 | Python | `references/stack-python.md` | ruff, black, pre-commit, pytest |
 | Rust | `references/stack-rust.md` | clippy, rustfmt, cargo test, GitHub Actions |
+| Go | `references/stack-go.md` | gofmt, golangci-lint, go test, GitHub Actions |
 | Other | `references/audit-prompt.md` | Adapt the universal artifacts to the toolchain present |
+
+Symphony readiness uses cross-stack references: `references/symphony-readiness.md`, `references/evidence-protocol.md`, and `references/smoke-ticket-eval.md`.
 
 ## Fix templates
 
-Use `references/fix-patterns.md`:
+Use `references/fix-patterns.md`.
 
-- `add-cold-start-brief`
-- `extract-rules-dir`
-- `add-rich-lint-messages`
-- `setup-pre-commit`
-- `wrap-test-runner`
-- `add-pr-review`
-- `seed-repo-skills`
-- `setup-gc-cadence`
+Focus/fix-template map:
+
+| Focus | Fix template |
+| --- | --- |
+| `cold-start-brief` | `add-cold-start-brief` |
+| `rules-dir` | `extract-rules-dir` |
+| `lint-messages` | `add-rich-lint-messages` |
+| `pre-commit` | `setup-pre-commit` |
+| `test-suite` | `wrap-test-runner` |
+| `pr-review` | `add-pr-review` |
+| `repo-skills` | `seed-repo-skills` |
+| `gc-cadence` | `setup-gc-cadence` |
+| `workflow-contract` | `add-workflow-contract` |
+| `workspace-bootstrap` | `add-disposable-bootstrap` |
+| `validate-loop` | `add-validate-loop` |
+| `app-validation` | `add-app-validation` |
+| `evidence-protocol` | `add-evidence-protocol` |
+| `ticket-lifecycle` | `add-ticket-lifecycle-skill` |
+| `observability` | `add-observability-access` |
+| `safety-policy` | `add-safety-policy` |
+| `smoke-ticket-eval` | `add-smoke-ticket-eval` |
 
 ## Output format
 
@@ -136,6 +221,31 @@ X/8 ✅, Y/8 ⚠️, Z/8 ❌
 1. **{name}** — what to add, est. effort, what unlocks
 2. ...
 3. ...
+
+## Symphony readiness overlay
+Include only for `symphony-readiness` and `audit+fix:symphony`.
+
+### 1. WORKFLOW.md contract
+**Status:** ✅ / ⚠️ / ❌
+**Evidence:** {file paths or "not found"}
+**Gap:** {1-2 lines}
+
+[... overlay items 2-9, same format ...]
+
+## Symphony readiness verdict
+Ready / Close / Not ready
+
+## Minimum blockers before unattended orchestration
+1. ...
+2. ...
+3. ...
+
+## Recommended smoke-ticket eval shape
+- Fixture: ...
+- Expected change: ...
+- Validation command: ...
+- Evidence required: ...
+- Cleanup: ...
 
 ## Notable strengths
 - ...

--- a/skills/harness-audit/references/audit-prompt.md
+++ b/skills/harness-audit/references/audit-prompt.md
@@ -80,7 +80,7 @@ When the requested mode is `symphony-readiness` or `audit+fix:symphony`, also us
 8. Safety, secrets, and workspace policy
 9. Smoke-ticket eval
 
-This overlay answers whether an unattended ticket-level orchestrator can safely run agents in this repo. Do not treat good docs/tests as sufficient if there is no disposable bootstrap, evidence path, or smoke-ticket proof.
+This overlay answers whether an unattended ticket-level orchestrator can safely run agents in this repo. Do not treat good docs/tests as sufficient if there is no disposable bootstrap, evidence path, tracker preflight, or smoke-ticket proof. For Linear workflows, verify the repo documents a live preflight command that checks the API key, project slug, and configured state names; without that, real Symphony readiness cannot be ✅.
 
 # Bonus signals to capture
 

--- a/skills/harness-audit/references/audit-prompt.md
+++ b/skills/harness-audit/references/audit-prompt.md
@@ -1,6 +1,11 @@
-# Audit Prompt Template
+# Audit Checklist / Delegation Prompt
 
-Use this as the audit checklist or as a prompt for a separate exploration agent when the host supports one. Replace the `{{...}}` placeholders before using it.
+Use this directly as the audit checklist. Paths in this file are relative to the skill root (`skills/harness-audit/`), not to the `references/` directory. When delegating to a separate exploration agent, first replace every `{{...}}` placeholder with concrete repo values; do not send unresolved placeholders to another agent.
+
+Placeholder sources:
+- `{{STACK}}`, `{{PACKAGE_MANAGER}}`, `{{REPO_PATH}}`, and `{{REPO_CONTEXT}}` come from stack detection and initial repo inspection.
+- `{{LINT_CONFIG_PATHS}}`, `{{TEST_RUNNER}}`, and `{{STACK_SPECIFIC_BONUS_SIGNALS}}` come from the matching stack reference.
+- `{{LINT_CMD}}` for fix templates must be derived from package scripts, Makefile targets, or the matching stack reference; if no lint command exists, report that as the gap instead of inventing one.
 
 ---
 
@@ -61,6 +66,22 @@ Concentration check: 5-10 deep skills > 50 shallow ones. Flag sprawl.
 ## 8. Garbage collection cadence
 This is hard to detect from code alone. Look for: weekly review docs, `CHANGELOG.md` with structured entries, `docs/` folder with retros/postmortems, `.github/ISSUE_TEMPLATE/` for "agent slop" or similar, `docs/decisions/` ADRs. Note any signal that PR feedback gets converted into rules/lints over time.
 
+# Symphony readiness overlay
+
+When the requested mode is `symphony-readiness` or `audit+fix:symphony`, also use `references/symphony-readiness.md` and score the repo on:
+
+1. `WORKFLOW.md` contract
+2. Disposable workspace bootstrap
+3. One-command validate loop
+4. Agent-visible app validation
+5. Evidence protocol
+6. Ticket/PR lifecycle skill
+7. Agent-readable observability
+8. Safety, secrets, and workspace policy
+9. Smoke-ticket eval
+
+This overlay answers whether an unattended ticket-level orchestrator can safely run agents in this repo. Do not treat good docs/tests as sufficient if there is no disposable bootstrap, evidence path, or smoke-ticket proof.
+
 # Bonus signals to capture
 
 `{{STACK_SPECIFIC_BONUS_SIGNALS}}` — read the matching `references/stack-{{STACK}}.md` for stack-specific things to look for here.
@@ -87,4 +108,15 @@ What's already well-set-up that should be preserved.
 ## Stack-specific observations
 Toolchain caveats agents need to know (Swift project file conflicts, Bun gotchas, Python venv conventions, etc.).
 
-Keep total report under ~1500 words. Be ruthless — gaps not present, but no padding.
+For Symphony modes, also include:
+
+## Symphony readiness overlay
+9-item scorecard with evidence and gaps.
+
+## Symphony readiness verdict
+Ready / Close / Not ready.
+
+## Minimum blockers before unattended orchestration
+The smallest set of fixes needed before a scheduler can run agents unattended.
+
+Keep baseline reports under ~1500 words. Keep Symphony reports under ~2200 words unless depth is requested. Be ruthless — gaps not present, but no padding.

--- a/skills/harness-audit/references/evidence-protocol.md
+++ b/skills/harness-audit/references/evidence-protocol.md
@@ -1,0 +1,68 @@
+# Evidence Protocol
+
+Use this reference when a repo needs human-reviewable proof for unattended agent work.
+
+## Evidence goals
+
+Evidence should answer three questions quickly:
+
+1. What behavior was reproduced or inspected before the change?
+2. What changed?
+3. What proves the acceptance criteria now pass?
+
+Raw logs are not enough. Agents should compress proof into a short workpad/PR section and attach durable artifacts only when they add signal.
+
+## Required evidence by change type
+
+| Change type | Minimum evidence |
+| --- | --- |
+| Pure docs | rendered/readback check or link check when available |
+| Library/API logic | targeted tests + relevant full suite/verify command |
+| CLI behavior | command transcript before/after |
+| UI behavior | screenshot or video + console error check + test command |
+| Runtime/perf | benchmark or trace/log query with threshold |
+| Bug fix | reproduction signal before fix + passing proof after fix |
+| Infra/CI | dry-run or CI link + failure-mode explanation |
+| Security/auth | negative test + positive test; never paste secrets |
+
+## Workpad / PR evidence section
+
+Agents should maintain a compact section like:
+
+```markdown
+## Evidence
+
+### Reproduction / baseline
+- `command`: outcome summary
+- artifact: `path-or-url`
+
+### Validation
+- `command`: pass/fail summary
+- `command`: pass/fail summary
+
+### UI/runtime proof
+- screenshot/video/log query: `path-or-url`
+- console/log errors checked: yes/no
+
+### Known limits
+- ...
+```
+
+## Artifact storage
+
+Prefer durable, reviewable locations:
+- PR comment attachments
+- issue/workpad attachments
+- `tmp/evidence/` ignored by git for local-only proof
+- CI artifact uploads
+
+Do not commit bulky generated evidence unless the repo already has that convention.
+
+## Agent instructions to add to repo skills
+
+- Capture evidence immediately after validation while context is fresh.
+- Quote only the useful tail/summary of long output.
+- Include exact commands, not paraphrases.
+- Include failing evidence when blocked.
+- Never claim UI behavior was validated without browser/app evidence.
+- Never claim CI is green without checking the current commit's checks.

--- a/skills/harness-audit/references/fix-patterns.md
+++ b/skills/harness-audit/references/fix-patterns.md
@@ -10,8 +10,7 @@ Repo: `{{REPO_PATH}}` ({{STACK}}, package manager: {{PKG_MGR}})
 Constraints from the repo operator docs:
 - Surgical fixes only — no refactors of unrelated code
 - Functional verification required — run the change and show output
-- Do not commit or push unless explicitly requested
-- Do not post to external systems unless explicitly requested
+- **Do not commit, push, open PRs, post comments, or call external systems unless explicitly requested.**
 - No emojis in committed files unless repo already uses them
 - kebab-case for new filenames
 
@@ -45,7 +44,7 @@ If the repo has a stale section saying "no commands yet" but commands DO exist, 
 
 After writing, ask: "is this lean enough to be useful at cold-start?" If >250 lines, cut.
 
-Verify: read it back end-to-end, then have the user agent (you, simulating cold-start) try to run the test command using only the brief. If you can't, the brief failed.
+Verify: read it back end-to-end, then ignore surrounding conversation context and try to run the documented test command using only the brief. If you can't, the brief failed.
 ```
 
 ---
@@ -75,6 +74,8 @@ Each file:
 
 After extracting, leave a 1-line pointer in the original location:
 > See `rules/naming-conventions.md` for naming standards.
+
+Preserve surrounding rationale when it is specific and useful. Move only the enforceable rule content; do not erase narrative context that explains why the rule exists unless that rationale moves into the new rule file.
 
 Update AGENTS.md to point to `rules/` in the "Where rules live" section.
 
@@ -128,19 +129,21 @@ Universal requirements:
 - Auto-fixable issues (formatting) get applied + restaged automatically
 
 Verification steps (REQUIRED):
-1. Stage a file with an intentional lint violation. Run the hook command directly (`pre-commit run`, `npx lint-staged`, `.git/hooks/pre-commit`, etc.). Show that it blocks or fixes.
-2. Stage a file with a type error. Run the hook command directly. Show that it blocks.
-3. Revert the test changes.
-4. Show the actual hook output for both cases.
+1. Prefer a scratch worktree or temporary branch so verification does not mutate the user's active index.
+2. Stage a file with an intentional lint violation. Run the hook command directly (`pre-commit run`, `npx lint-staged`, `.git/hooks/pre-commit`, etc.). Show that it blocks or fixes.
+3. Stage a file with a type error. Run the hook command directly. Show that it blocks.
+4. Revert the test changes and restore the original branch/index.
+5. Show the actual hook output for both cases.
 
 Only run a real `git commit` when the user explicitly requested commit-based verification.
 
 Don't claim done until you've shown evidence.
 
-For Node/TS: bun add -D husky lint-staged, husky init, configure lint-staged in package.json.
-For Swift: native `.git/hooks/pre-commit` shell script with swiftlint.
+For Node/TS: `bun add -D husky lint-staged`, `bunx husky init`, configure lint-staged in package.json.
+For Swift: tracked `scripts/git-hooks/pre-commit` plus `make install-hooks`/installer that symlinks into `.git/hooks/`; do not rely on committing `.git/hooks/` directly.
 For Python: `pre-commit install` after writing `.pre-commit-config.yaml`.
-For Rust: native `.git/hooks/pre-commit` running `cargo fmt --check` and `cargo clippy`.
+For Rust: tracked `scripts/git-hooks/pre-commit` plus `make install-hooks`/installer running `cargo fmt --check` and `cargo clippy`; do not rely on committing `.git/hooks/` directly.
+For Go: tracked hook installer or pre-commit framework running `gofmt`, `go vet`, and `golangci-lint` when present.
 
 If commits were explicitly requested, use commit message: `chore: add pre-commit hook running {tools}`. Match repo conventions.
 ```
@@ -208,7 +211,7 @@ Path A is simpler if CodeRabbit is acceptable. Path B is better if Ossie wants p
 
 Default: Path A unless audit found Ossie already runs CodeRabbit elsewhere and is dissatisfied.
 
-Verify: open a draft PR with an intentional issue (a TODO, a console.log) and confirm the review fires within 5 min.
+Verify: validate config syntax and file placement locally. Treat CodeRabbit GitHub App installation as a hard gate: verify it is installed for the repo/org, or print a clear `App not installed — config is dormant` warning and leave PR review automation as partial. Only open a draft PR with an intentional issue when the user explicitly authorizes external GitHub-side verification; otherwise document the exact manual verification command/steps.
 ```
 
 ---
@@ -255,7 +258,7 @@ Use when: artifact #8 is ❌ Missing.
 ```
 Set up a "garbage collection day" ritual converting agent/PR feedback into permanent rules. Two pieces:
 
-1. **Schedule** — If a scheduling tool is available and the user explicitly wants automation, create a recurring routine (Friday 14:00 local) that:
+1. **Schedule** — If a scheduling tool is available and the user explicitly wants automation, ask for or use the repo's documented cadence. If unspecified, document a manual weekly cadence instead of hardcoding a time. The routine should:
    - Pulls the week's PR review comments
    - Pulls any "agent slop" issues / labels
    - Drafts proposed rule additions or lint changes
@@ -275,6 +278,208 @@ Verify: for automated cadence, trigger a manual run and confirm it produces outp
 
 ---
 
+## `add-workflow-contract`
+
+Use when: Symphony overlay #1 is ❌ Missing or ⚠️ Partial.
+
+```
+Seed or improve a repo-local `WORKFLOW.md` using `references/workflow-template.md`.
+
+Rules:
+- Use obvious placeholders for tracker slug, repo URL, and credentials.
+- Do not paste real tokens or personal local paths.
+- Match the repo's real validation/bootstrap commands when they exist.
+- If commands do not exist yet, point to the scripts this fix also creates or mark the placeholder clearly.
+- Include state semantics for Todo, In Progress, Human Review, Rework, Merging, and terminal states, adjusted to the repo's tracker workflow.
+- Include explicit handoff criteria and evidence requirements.
+
+Verify: parse the YAML front matter manually or with an available YAML parser; confirm no secrets are present; confirm referenced scripts exist or are marked TODO placeholders.
+```
+
+---
+
+## `add-disposable-bootstrap`
+
+Use when: Symphony overlay #2 is ❌ Missing or ⚠️ Partial.
+
+```
+Add a minimal disposable bootstrap path such as `scripts/bootstrap.sh` and, when useful, `scripts/verify-ready.sh`.
+
+Requirements:
+- strict shell mode (`set -euo pipefail`)
+- install dependencies using the repo's package manager
+- document required env vars through `.env.example` or AGENTS.md
+- avoid machine-specific absolute paths
+- avoid destructive cleanup outside the current repo/workspace
+- be safe to run in a freshly cloned workspace
+
+Verify in a temporary directory when cheap. If full install is too expensive, run syntax checks and the cheapest dry-run available, then state exactly what was not executed.
+```
+
+---
+
+## `add-evidence-protocol`
+
+Use when: Symphony overlay #5 is ❌ Missing or ⚠️ Partial.
+
+```
+Add `docs/agent-evidence.md` or an equivalent section using `references/evidence-protocol.md`.
+
+Then wire it into AGENTS.md / repo skills / WORKFLOW.md so agents actually read it.
+
+Must define:
+- evidence by change type
+- required reproduction signal
+- validation command transcript expectations
+- screenshot/video/log expectations for UI/runtime work
+- where evidence should be attached or stored
+- what not to claim without proof
+
+Verify: ensure the cold-start brief or workflow points to the evidence doc.
+```
+
+---
+
+## `add-validate-loop`
+
+Use when: Symphony overlay #3 is ❌ Missing or ⚠️ Partial.
+
+```
+Add one stable validation command that represents the meaningful pre-handoff quality gate.
+
+Prefer the repo's existing convention:
+- `make verify`
+- `./scripts/verify.sh`
+- `pnpm verify` / `npm run verify`
+- `uv run ...`
+- `cargo test --workspace && cargo clippy ...`
+- `go test ./... && go vet ./...`
+
+The command should run, as applicable:
+- lint/format check
+- typecheck/compile
+- unit/integration tests that are safe locally
+- app smoke check when cheap and deterministic
+
+If `wrap-test-runner` already created `scripts/test.sh` or an equivalent test wrapper, extend or call that wrapper from the validate loop instead of creating a parallel, inconsistent test script.
+
+If full validation is slow, expose tiers such as `verify-fast` and `verify-full`, and document which one Symphony agents must run before handoff.
+
+Wire the command into AGENTS.md, WORKFLOW.md, and the ticket lifecycle skill.
+
+Verify: run the fastest real validation tier. If full validation is intentionally skipped due to cost, state the exact skipped command and why.
+```
+
+---
+
+## `add-app-validation`
+
+Use when: Symphony overlay #4 is ❌ Missing or ⚠️ Partial.
+
+```
+Add the smallest agent-visible app validation path for the repo.
+
+Prefer existing tools and scripts. Do not install a full browser/observability stack unless the repo already uses it.
+
+For web apps, add or document:
+- one app launch command (`scripts/launch-app.sh`, `make dev`, `pnpm dev`, etc.)
+- one browser validation path (Playwright, Cypress, agent-browser, Chrome DevTools, or existing E2E runner)
+- screenshot/video capture command if available
+- browser console/server log capture instructions
+- shutdown/cleanup command
+- deterministic seed/test user instructions when needed
+
+For service/CLI repos, adapt this to a smoke request/CLI invocation plus log capture.
+
+Wire the path into AGENTS.md, the ticket lifecycle skill, or WORKFLOW.md so agents actually use it for UI/runtime changes.
+
+Verify: run the launch command when cheap and show a healthy empty-state/log output. If browser automation is not configured, document the gap explicitly instead of claiming app validation is ready.
+```
+
+---
+
+## `add-ticket-lifecycle-skill`
+
+Use when: Symphony overlay #6 is ❌ Missing or ⚠️ Partial.
+
+```
+Create a repo-scoped skill/prompt for ticket execution, preferably in the repo's existing skill system. Use `.agents/skills/ticket-lifecycle/SKILL.md` for cross-harness repos when no convention exists.
+
+Include:
+- read ticket and acceptance criteria
+- maintain one persistent workpad/comment
+- branch/worktree policy
+- plan/reproduce/implement/validate/handoff loop
+- PR creation/update policy
+- review comment sweep
+- rework policy
+- landing policy
+- blocker policy
+
+Keep it 60-120 lines. Link out to evidence, testing, and landing docs instead of embedding everything.
+
+Verify: read the skill end-to-end and ensure every linked file exists.
+```
+
+---
+
+## `add-observability-access`
+
+Use when: Symphony overlay #7 is ❌ Missing or ⚠️ Partial.
+
+```
+Document or add the smallest agent-readable observability path.
+
+Prefer:
+- `scripts/logs.sh` for local service logs
+- `scripts/ci-failure-summary.sh` for CI logs
+- browser console capture instructions for UI apps
+- metrics/traces query commands if the repo already has them
+
+Do not invent a full observability stack during a harness fix. Add the thinnest stable wrapper around existing signals.
+
+Verify: run the wrapper against existing logs or show a clear empty-state output.
+```
+
+---
+
+## `add-safety-policy`
+
+Use when: Symphony overlay #8 is ❌ Missing or ⚠️ Partial.
+
+```
+Add a short `docs/agent-safety.md` or AGENTS.md section covering:
+- secrets via env vars only
+- required `.env.example` entries
+- workspace-only editing expectation
+- destructive command policy
+- external posting/publishing policy
+- sandbox/approval posture
+- cleanup boundaries
+
+Verify: run the repo's secret scanner if present, preferably `gitleaks detect --staged` or `gitleaks detect --no-git --source <changed-path>`. If no scanner is present, document that as a remaining safety gap; then grep added files for common token names (`API_KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `PRIVATE_KEY`) and confirm no values were introduced. Do not mark the secret-scan gate as complete unless an actual scanner or CI gate exists.
+```
+
+---
+
+## `add-smoke-ticket-eval`
+
+Use when: Symphony overlay #9 is ❌ Missing.
+
+```
+Add a local smoke-ticket fixture and runner based on `references/smoke-ticket-eval.md`.
+
+Prefer:
+- `docs/agent-evals/smoke-ticket.md`
+- `scripts/agent-smoke-eval.sh`
+
+The first version may be a dry-run verifier that checks the fixture, expected marker file, validation command, and evidence section shape. Do not require real tracker credentials unless the user explicitly wants live integration. If the eval is a placeholder, make it fail by default in CI or exclude it from CI with an explicit TODO; do not let a stub silently pass.
+
+Verify: prefer the dry-run path and show pass/fail output. A live smoke-ticket eval may spawn agents, create worktrees, call external trackers, and burn tokens; run it only with explicit user approval. If it is intentionally a template, make that explicit and ensure it exits non-zero until configured.
+```
+
+---
+
 ## Execution order
 
 When running `audit+fix` mode and multiple gaps need fixing:
@@ -285,7 +490,12 @@ When running `audit+fix` mode and multiple gaps need fixing:
 
 **Sequential required (overlapping files):**
 - `setup-pre-commit` BEFORE `add-rich-lint-messages` (the second needs the first's lint config in place)
-- `wrap-test-runner` BEFORE `add-cold-start-brief` (the brief points at the script)
+- `wrap-test-runner` / `add-validate-loop` BEFORE `add-cold-start-brief` (the brief points at validation scripts)
 - `extract-rules-dir` BEFORE `add-rich-lint-messages` (lint messages point at rules)
+- `wrap-test-runner` / `add-validate-loop` / `add-disposable-bootstrap` BEFORE `add-workflow-contract` (workflow hooks should reference real commands)
+- `add-evidence-protocol` BEFORE `add-ticket-lifecycle-skill` (ticket skill should link to evidence rules)
+- `add-app-validation` BEFORE `add-ticket-lifecycle-skill` when ticket skill references UI/runtime proof
+- `add-ticket-lifecycle-skill` BEFORE `add-workflow-contract` when the workflow prompt references repo skills
+- `add-smoke-ticket-eval` AFTER validation/bootstrap scripts exist
 
 When in doubt, sequential. Wrong parallelization causes conflicts; wrong sequencing only costs time.

--- a/skills/harness-audit/references/smoke-ticket-eval.md
+++ b/skills/harness-audit/references/smoke-ticket-eval.md
@@ -1,0 +1,69 @@
+# Smoke-Ticket Eval
+
+A smoke-ticket eval proves the repo is ready for ticket-level unattended orchestration.
+
+This can be implemented against a real tracker or as a local dry-run fixture. Prefer local first; it is cheaper and safer.
+
+## Minimal fixture
+
+Create a tiny issue fixture such as `docs/agent-evals/smoke-ticket.md`:
+
+```markdown
+# SMOKE-001: Update smoke-test marker
+
+## Goal
+Make the smallest safe change that proves the agent can edit, validate, and hand off.
+
+## Acceptance criteria
+- Change the configured marker text from `before` to `after` in the documented fixture file.
+- Run the repo validation command.
+- Record evidence in the workpad/PR section.
+- Do not touch unrelated files.
+
+## Validation
+- Run `./scripts/verify.sh` or the repo's equivalent validation command.
+```
+
+## Eval harness expectations
+
+A runnable eval should:
+
+1. create a disposable workspace or git worktree
+2. render the repo's workflow prompt with the fixture issue
+3. launch the selected agent runner or dry-run substitute
+4. require the expected file change
+5. require validation evidence
+6. verify no unrelated tracked files changed
+7. clean up workspace state unless debugging is requested
+
+## Pass/fail criteria
+
+Pass only when:
+- expected change exists
+- validation command was run and recorded
+- evidence section exists
+- no unrelated files changed
+- run completes without human prompt/input
+
+Fail when:
+- the agent asks the human what to do despite clear fixture instructions
+- it cannot bootstrap the workspace
+- it edits outside the workspace
+- it skips validation
+- it claims evidence without artifact/command proof
+
+## Practical script shape
+
+A repo can expose this as:
+
+```bash
+./scripts/agent-smoke-eval.sh
+```
+
+or:
+
+```bash
+make agent-smoke-eval
+```
+
+The script may use a cheap stub agent first. The important part is that the repo has an executable definition of what "ready for unattended ticket work" means.

--- a/skills/harness-audit/references/stack-go.md
+++ b/skills/harness-audit/references/stack-go.md
@@ -1,0 +1,114 @@
+# Go Stack
+
+Covers: Go modules, CLIs, services, workers, monorepos with multiple Go modules.
+
+## Tooling matrix
+
+| Concern | Recommended | Alternatives |
+| --- | --- | --- |
+| Format | `gofmt` / `go fmt` | `gofumpt` |
+| Lint | `golangci-lint` | `go vet`, staticcheck |
+| Test runner | `go test ./...` | gotestsum, richgo |
+| Pre-commit | pre-commit framework or tracked hook installer | lefthook |
+| CI | GitHub Actions | Buildkite, CircleCI |
+
+## Config paths to check
+
+- `go.mod`, `go.sum`
+- `go.work`, `go.work.sum`
+- `.golangci.yml`, `.golangci.yaml`, `.golangci.toml`, `.golangci.json`
+- `Makefile`, `Taskfile.yml`, `justfile`
+- `.github/workflows/*`
+
+## Pre-commit pattern
+
+Prefer tracked hook scripts plus an installer, or the pre-commit framework. Do not rely on writing only to `.git/hooks/`; that directory is not version-controlled.
+
+Example tracked hook:
+
+`scripts/git-hooks/pre-commit`:
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+
+STAGED_GO=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.go$' || true)
+if [ -z "$STAGED_GO" ]; then
+  exit 0
+fi
+
+# Format staged Go files and restage them.
+echo "$STAGED_GO" | xargs gofmt -w
+echo "$STAGED_GO" | xargs git add
+
+go vet ./...
+if command -v golangci-lint >/dev/null 2>&1; then
+  golangci-lint run ./...
+fi
+```
+
+`Makefile`:
+```make
+install-hooks:
+	mkdir -p .git/hooks
+	ln -sf ../../scripts/git-hooks/pre-commit .git/hooks/pre-commit
+```
+
+## Test wrapper
+
+`go test ./...` is the baseline one-liner. For agent use, expose a stable command:
+
+```make
+verify:
+	go test ./...
+	go vet ./...
+	golangci-lint run ./...
+```
+
+For slow integration tests, use build tags:
+
+```sh
+go test ./...                  # fast/unit
+go test -tags=integration ./... # integration
+```
+
+## CI pattern (GitHub Actions)
+
+```yaml
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: go test ./...
+      - run: go vet ./...
+      - uses: golangci/golangci-lint-action@v6
+```
+
+## Go-specific gotchas to flag
+
+- **Context propagation** — services should pass `context.Context`; flag long-running calls without timeout/deadline.
+- **Ignored errors** — `errcheck` or `golangci-lint` should catch these.
+- **Global mutable state** — parallel tests and agent edits often expose races; recommend `go test -race ./...` for critical packages.
+- **Integration tests hitting real services** — require env-gated tests and `.env.example` docs.
+- **Generated code drift** — check `go generate ./...` or documented generation commands.
+- **Multiple modules** — `go test ./...` from one module will not cover sibling modules unless `go.work` or a wrapper exists.
+
+## Repo skills worth seeding
+
+- `run-go-tests` — wraps fast/unit/integration/race variants
+- `regen-go-code` — wraps `go generate ./...` and protobuf/sqlc generation
+- `inspect-ci-failure` — summarizes failing Go test output from CI
+
+## Bonus signals (for the audit prompt)
+
+- Go version (`go` directive in `go.mod`)
+- Single module vs `go.work` workspace
+- Race test coverage for concurrent code
+- Presence of generated code (`// Code generated`, `sqlc`, protobuf, mockgen)
+- Service framework hints (gin, chi, echo, connect-go, grpc)

--- a/skills/harness-audit/references/stack-rust.md
+++ b/skills/harness-audit/references/stack-rust.md
@@ -21,7 +21,9 @@ Covers: Rust 1.70+, Cargo workspaces, embedded Rust, web (axum/actix), Tauri.
 
 ## Pre-commit pattern
 
-`.git/hooks/pre-commit`:
+Do not rely on committing `.git/hooks/` directly; it is not version-controlled. Put the hook in `scripts/git-hooks/pre-commit` and add `make install-hooks` or an equivalent installer that symlinks/copies it into `.git/hooks/pre-commit`.
+
+`scripts/git-hooks/pre-commit`:
 ```sh
 #!/usr/bin/env bash
 set -euo pipefail
@@ -35,6 +37,19 @@ cargo clippy --workspace --all-targets -- -D warnings
 # Tests scoped to changed crates would be ideal but cargo doesn't do incremental test selection well.
 # For small projects: cargo test --workspace
 # For large: skip tests in pre-commit, rely on pre-push or CI
+```
+
+Example installer:
+
+```make
+install-hooks:
+	mkdir -p .git/hooks
+	chmod +x scripts/git-hooks/pre-commit
+	@if [ -e .git/hooks/pre-commit ] && [ ! -L .git/hooks/pre-commit ]; then \
+		echo ".git/hooks/pre-commit exists and is not a symlink; refusing to overwrite"; \
+		exit 1; \
+	fi
+	ln -sf ../../scripts/git-hooks/pre-commit .git/hooks/pre-commit
 ```
 
 For larger workspaces (>30s `cargo build`), use `cargo nextest run` and only test the workspace member containing staged files.

--- a/skills/harness-audit/references/stack-swift.md
+++ b/skills/harness-audit/references/stack-swift.md
@@ -64,7 +64,9 @@ esac
 
 ## Pre-commit pattern
 
-`.git/hooks/pre-commit`:
+Do not rely on committing `.git/hooks/` directly; it is not version-controlled. Put the hook in `scripts/git-hooks/pre-commit` and add `make install-hooks` or an equivalent installer that symlinks/copies it into `.git/hooks/pre-commit`.
+
+`scripts/git-hooks/pre-commit`:
 ```sh
 #!/usr/bin/env bash
 set -euo pipefail
@@ -81,9 +83,20 @@ fi
 # xcodebuild build -project MyApp.xcodeproj -scheme MyApp -quiet
 ```
 
-`chmod +x .git/hooks/pre-commit` after creating.
+Example installer:
 
-For team-wide enforcement (since `.git/hooks/` isn't tracked), put the script in `scripts/git-hooks/pre-commit` and add a `make install-hooks` target that symlinks them.
+```make
+install-hooks:
+	mkdir -p .git/hooks
+	chmod +x scripts/git-hooks/pre-commit
+	@if [ -e .git/hooks/pre-commit ] && [ ! -L .git/hooks/pre-commit ]; then \
+		echo ".git/hooks/pre-commit exists and is not a symlink; refusing to overwrite"; \
+		exit 1; \
+	fi
+	ln -sf ../../scripts/git-hooks/pre-commit .git/hooks/pre-commit
+```
+
+Run `make install-hooks` after cloning.
 
 ## CI pattern (GitHub Actions, macOS)
 

--- a/skills/harness-audit/references/symphony-readiness.md
+++ b/skills/harness-audit/references/symphony-readiness.md
@@ -14,6 +14,7 @@ Look for a repo-local `WORKFLOW.md` or equivalent orchestrator contract.
 
 Must include:
 - tracker config placeholders, not hardcoded personal secrets
+- real tracker preflight command/instructions that verify the project/key/states exist before unattended runs
 - active, review, rework, merge, and terminal state semantics
 - workspace bootstrap hooks or pointers
 - agent command / sandbox / approval posture
@@ -81,6 +82,7 @@ Strong signal: evidence is compressed for humans. Raw logs alone are weak.
 
 Look for a repo-scoped skill/prompt that covers:
 - read ticket and acceptance criteria
+- verify the tracker project exists and configured state names match the real tracker workflow before launch
 - maintain one persistent workpad/comment
 - create branch/worktree
 - open/update PR
@@ -129,7 +131,7 @@ Look for a documented or runnable eval that:
 5. verifies the handoff state/comment/PR body
 6. cleans up disposable state
 
-If no external tracker is available, a local fixture issue file is acceptable for a dry-run eval.
+If no external tracker is available, a local fixture issue file is acceptable for a dry-run eval. If Linear is the tracker, a live preflight like `bun run symphony validate WORKFLOW.md --live-tracker` must pass before scoring this as runnable against the real tracker.
 
 ## Output addendum
 

--- a/skills/harness-audit/references/symphony-readiness.md
+++ b/skills/harness-audit/references/symphony-readiness.md
@@ -1,0 +1,160 @@
+# Symphony Readiness Overlay
+
+Use this overlay when the user asks for Symphony readiness, ticket-level agent automation, unattended agent execution, or preparing a repo for an orchestrator like Symphony.
+
+Baseline harness readiness asks: **can agents understand and edit this repo?**
+
+Symphony readiness asks: **can an unattended agent pick up a ticket, work in isolation, validate the change, produce reviewable evidence, and hand off through the tracker/PR workflow without babysitting?**
+
+Score each item `✅ Present / ⚠️ Partial / ❌ Missing` with concrete path evidence and one-line gap.
+
+## 1. `WORKFLOW.md` contract
+
+Look for a repo-local `WORKFLOW.md` or equivalent orchestrator contract.
+
+Must include:
+- tracker config placeholders, not hardcoded personal secrets
+- active, review, rework, merge, and terminal state semantics
+- workspace bootstrap hooks or pointers
+- agent command / sandbox / approval posture
+- prompt body with ticket lifecycle rules
+- handoff definition: what counts as ready for human review
+
+Strong signal: workflow is versioned with the repo and written as a durable operating contract, not a one-off launch command.
+
+## 2. Disposable workspace bootstrap
+
+Verify a fresh workspace can be prepared without hidden local state.
+
+Look for:
+- clone/setup command
+- dependency install command
+- environment template (`.env.example`, `mise.toml`, `.tool-versions`, `devcontainer.json`)
+- database/service bootstrap command when applicable
+- cleanup command
+
+Audit question: from an empty directory, can an agent create the same working environment Symphony will create per ticket?
+
+## 3. One-command validate loop
+
+Look for one stable command that runs the meaningful quality gate:
+- tests
+- typecheck/compile
+- lint/format check
+- app smoke check where applicable
+
+Good names: `make all`, `make verify`, `./scripts/verify.sh`, `pnpm verify`, `uv run pytest`, `cargo test`.
+
+Flag commands that only work after undocumented setup, require interactive input, or run only a narrow subset while claiming full validation.
+
+Check this even when baseline artifact #5 passes. Baseline tests can exist while the unattended validate loop is still incomplete or too narrow for Symphony.
+
+## 4. Agent-visible app validation
+
+For UI/service repos, check whether an agent can launch and inspect the app.
+
+Look for:
+- `scripts/launch-app.*`, `make dev`, `docker compose up`, or equivalent
+- Playwright/Cypress/agent-browser/Chrome DevTools instructions
+- deterministic test user/seed data
+- console/server log capture
+- screenshot/video capture
+- shutdown/cleanup instructions
+
+If the repo has user-facing behavior but no agent-visible app path, score this low even if unit tests exist.
+
+## 5. Evidence protocol
+
+Check for instructions that tell the agent what proof to produce.
+
+Evidence may include:
+- reproduction signal before changes
+- test command and output summary
+- screenshot/video for UI changes
+- logs/metrics/traces for runtime changes
+- PR comment or issue workpad update
+- CI/check URL after push
+
+Strong signal: evidence is compressed for humans. Raw logs alone are weak.
+
+## 6. Ticket/PR lifecycle skill
+
+Look for a repo-scoped skill/prompt that covers:
+- read ticket and acceptance criteria
+- maintain one persistent workpad/comment
+- create branch/worktree
+- open/update PR
+- gather and resolve review comments
+- push back or defer out-of-scope feedback
+- move to human review
+- handle rework by starting clean when needed
+- land/merge only through approved flow
+
+This can live under `.codex/skills/`, `.agents/skills/`, `.pi/skills/`, `.claude/skills/`, or `docs/agent-workflows/`.
+
+## 7. Agent-readable observability
+
+Check whether agents can query the signals needed to debug without human screenshots.
+
+Look for:
+- local app logs with clear paths
+- structured logs
+- summarized CI failure extraction
+- metrics/traces query instructions
+- browser console capture
+- production log access docs, with safe scoping
+
+Raw vendor dashboards with no CLI/API path are partial at best.
+
+## 8. Safety, secrets, and workspace policy
+
+Check that unattended execution has explicit boundaries:
+- secrets loaded via env vars or secret manager, never pasted into docs
+- `.env.example` names required vars without values
+- destructive commands documented and guarded
+- workspace path isolation expected
+- generated artifacts ignored or scoped
+- external posting/publishing requires configured credentials and clear policy
+- sandbox/approval posture documented
+
+## 9. Smoke-ticket eval
+
+Best readiness proof: a tiny issue can be completed end-to-end by the workflow.
+
+Look for a documented or runnable eval that:
+1. creates or simulates a small ticket
+2. launches the orchestrated agent flow in a disposable workspace
+3. requires a branch/PR or local patch
+4. requires validation evidence
+5. verifies the handoff state/comment/PR body
+6. cleans up disposable state
+
+If no external tracker is available, a local fixture issue file is acceptable for a dry-run eval.
+
+## Output addendum
+
+After the 8 baseline harness artifacts, add:
+
+```markdown
+## Symphony readiness overlay
+
+### 1. WORKFLOW.md contract
+**Status:** ✅ / ⚠️ / ❌
+**Evidence:** ...
+**Gap:** ...
+
+[... items 2-9 ...]
+
+## Symphony readiness verdict
+Ready / Close / Not ready
+
+## Minimum blockers before unattended orchestration
+1. ...
+2. ...
+3. ...
+```
+
+Verdict guide:
+- **Ready:** no ❌ items, and a smoke-ticket eval is runnable end-to-end against a fixture. Placeholder docs or non-functional templates do not qualify.
+- **Close:** no launch-blocking ❌ items in workflow contract, disposable bootstrap, validate loop, evidence protocol, ticket lifecycle, or safety policy; and app validation/observability/smoke eval gaps are documented as remaining work. Also use Close when all items are ✅/⚠️ but the smoke-ticket eval is not yet runnable.
+- **Not ready:** no disposable bootstrap, no workflow contract, no validation/evidence path, unsafe secrets/workspace policy, or any other gap that would make unattended execution fail before meaningful work starts.

--- a/skills/harness-audit/references/workflow-template.md
+++ b/skills/harness-audit/references/workflow-template.md
@@ -74,6 +74,16 @@ No description provided.
 - `Merging`: follow the repo landing skill; do not bypass required merge policy.
 - Terminal states: do nothing.
 
+## Required preflight
+
+Before unattended execution, run the tracker preflight and fix every error:
+
+```bash
+bun run symphony validate WORKFLOW.md --live-tracker
+```
+
+This must verify the tracker API key, project slug, active states, terminal states, and lifecycle states against the real tracker workflow. Do not start polling if preflight fails.
+
 ## Required handoff
 
 Before moving to human review, ensure:
@@ -93,4 +103,5 @@ Before moving to human review, ensure:
 - The `after_create` hook must be safe in an empty workspace.
 - Do not hardcode personal API tokens, local absolute repo paths, or private machine names.
 - Customize `tracker.kind` and state names to the actual tracker workflow.
+- Include a live tracker preflight command for the actual orchestrator; for Symphony + Linear use `bun run symphony validate WORKFLOW.md --live-tracker`.
 - If targeting OpenAI's Elixir reference implementation, use `tracker.kind: linear` and adapt `agent_runner` to its current `codex` front-matter schema. This generic template is intentionally runner-adapter-neutral.

--- a/skills/harness-audit/references/workflow-template.md
+++ b/skills/harness-audit/references/workflow-template.md
@@ -1,0 +1,96 @@
+# Minimal `WORKFLOW.md` Template
+
+Use this as a starting point when `audit+fix:symphony` needs to seed a repo-local Symphony contract. Keep placeholders obvious. Do not add real secrets.
+
+```md
+---
+tracker:
+  kind: "REPLACE_WITH_TRACKER_KIND" # examples: linear, github, jira, custom
+  project_slug: "REPLACE_WITH_PROJECT_SLUG"
+  api_key: $LINEAR_API_KEY
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  terminal_states:
+    - Done
+    - Closed
+    - Cancelled
+    - Canceled
+    - Duplicate
+polling:
+  interval_ms: 30000
+workspace:
+  root: "REPLACE_WITH_WORKSPACE_ROOT"
+hooks:
+  after_create: |
+    git clone REPLACE_WITH_REPO_URL .
+    ./scripts/bootstrap.sh
+  before_run: |
+    ./scripts/verify-ready.sh
+agent:
+  max_concurrent_agents: 2
+  max_turns: 20
+  max_retry_backoff_ms: 300000
+agent_runner:
+  kind: "REPLACE_WITH_AGENT_RUNNER_KIND" # examples: codex, claude, pi, custom
+  command: "REPLACE_WITH_AGENT_APP_SERVER_COMMAND"
+  sandbox: "REPLACE_WITH_SANDBOX_OR_APPROVAL_POLICY"
+---
+
+You are working on ticket `{{ issue.identifier }}`.
+
+Title: {{ issue.title }}
+State: {{ issue.state }}
+URL: {{ issue.url }}
+Labels: {{ issue.labels }}
+
+Description:
+{% if issue.description %}
+{{ issue.description }}
+{% else %}
+No description provided.
+{% endif %}
+
+## Operating contract
+
+- Work only inside the provided workspace.
+- Start by reading repo-local agent instructions (`AGENTS.md`, repo skills, and rules docs).
+- Maintain one persistent workpad/comment for plan, acceptance criteria, validation, evidence, and blockers.
+- Before edits, capture a reproduction signal or state why reproduction is not applicable.
+- Keep scope tied to the ticket acceptance criteria.
+- File follow-up work separately instead of expanding scope.
+- Run the repo's required validation before handoff.
+- Produce compressed evidence a human can review quickly.
+- Stop only for true blockers: missing auth, missing required secrets, or impossible acceptance criteria.
+
+## State flow
+
+- `Todo`: move to `In Progress`, create/update workpad, then execute.
+- `In Progress`: continue from current workpad and workspace state.
+- `Rework`: re-read feedback, start from a clean branch/workspace when policy requires it, then execute.
+- `Human Review`: do not code unless feedback moves the ticket back to `Rework`.
+- `Merging`: follow the repo landing skill; do not bypass required merge policy.
+- Terminal states: do nothing.
+
+## Required handoff
+
+Before moving to human review, ensure:
+
+- plan/checklist is current and complete
+- acceptance criteria are checked off
+- validation command(s) and results are recorded
+- UI/runtime evidence is attached when behavior is user-facing
+- PR is opened or updated, if this repo uses PRs
+- review comments and CI failures are resolved or explicitly pushed back with rationale
+```
+
+## Template rules
+
+- Keep this file repo-local and versioned.
+- Prefer placeholders over environment-specific values.
+- The `after_create` hook must be safe in an empty workspace.
+- Do not hardcode personal API tokens, local absolute repo paths, or private machine names.
+- Customize `tracker.kind` and state names to the actual tracker workflow.
+- If targeting OpenAI's Elixir reference implementation, use `tracker.kind: linear` and adapt `agent_runner` to its current `codex` front-matter schema. This generic template is intentionally runner-adapter-neutral.


### PR DESCRIPTION
## Summary
- Add Claude Code plugin marketplace ports for `ask-codex`, `deep-dive`, and `skill-stats`.
- Register the new plugins in `.claude-plugin/marketplace.json`.
- Strengthen the public `bambu-slicer` Agent Skill with stacking / print-by-object guidance and 3MF identical-plate gotchas.

## Linked issues
Refs #1
Refs #3

## Verification
- `gh api user --jq '{login:.login,name:.name}'`
- `gitleaks protect --staged --redact --no-banner --config=.gitleaks.toml`
- `npm run check`
- `npm run pack:dry`
- pre-commit hook: gitleaks, lint-staged, typecheck, smoke test

## Notes
- Created #3 to track a later true end-to-end `bambu-slicer` skill test with local OrcaSlicer/Bambu Studio profiles and a temporary STL/3MF outside the repo.
