### PR TITLE
security: bump protobufjs to 7.5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3810,9 +3810,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs,cjs,json,md,yml,yaml}": "biome check --write --no-errors-on-unmatched"
+  },
+  "overrides": {
+    "protobufjs": ">=7.5.6"
   }
 }


### PR DESCRIPTION
Addresses GitHub security advisory: high-severity code injection + DoS via unbounded recursion in protobufjs <7.5.6.

`protobufjs` is a transitive dev dependency in this repo (pulled in via the lockfile, no direct entry in `package.json`). This PR:

- Adds a top-level `overrides` entry pinning `protobufjs` to `>=7.5.6` so future installs resolve the patched version.
- Updates the existing `node_modules/protobufjs` entry in `package-lock.json` from `7.5.5` → `7.5.6`, refreshing the resolved URL and integrity hash from the npm registry.

No direct API surface in this repo uses protobufjs, but bumping closes the advisory in the lockfile and prevents regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)