### PR TITLE
Teach harness audit API documentation policy checks

### DIFF
--- a/skills/harness-audit/SKILL.md
+++ b/skills/harness-audit/SKILL.md
@@ -44,7 +44,6 @@ Numeric aliases:
 | `focus:6` | `pr-review` |
 | `focus:7` | `repo-skills` |
 | `focus:8` | `gc-cadence` |
-| `focus:api-doc-policy` | `api-doc-policy` |
 | `focus:symphony-1` | `workflow-contract` |
 | `focus:symphony-2` | `workspace-bootstrap` |
 | `focus:symphony-3` | `validate-loop` |

--- a/skills/harness-audit/SKILL.md
+++ b/skills/harness-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-audit
-description: Audit a repository for autonomous-agent harness readiness and Symphony-style unattended ticket execution readiness across cold-start docs, rules, lint, hooks, tests, PR automation, repo skills, garbage-collection cadence, workflow contracts, evidence, observability, and smoke-ticket evals. Use for "harness audit", "agent-ready repo", "harness readiness", "make this repo agent-friendly", "Symphony readiness", "prepare this repo for Symphony", "ticket-level agent automation", or surgical fixes for top harness gaps.
+description: Audit a repository for autonomous-agent harness readiness and Symphony-style unattended ticket execution readiness across cold-start docs, rules, API documentation policy/ADRs, lint, hooks, tests, PR automation, repo skills, garbage-collection cadence, workflow contracts, evidence, observability, and smoke-ticket evals. Use for "harness audit", "agent-ready repo", "harness readiness", "make this repo agent-friendly", "API docs policy", "Symphony readiness", "prepare this repo for Symphony", "ticket-level agent automation", or surgical fixes for top harness gaps.
 ---
 
 # Harness Audit
@@ -30,7 +30,7 @@ Natural-language mapping:
 
 Tie-breaker: default to baseline modes unless the user explicitly says Symphony, ticket-level orchestration, unattended execution, scheduler, tracker workflow, or workflow contract.
 
-Accepted focus names: `cold-start-brief`, `rules-dir`, `lint-messages`, `pre-commit`, `test-suite`, `pr-review`, `repo-skills`, `gc-cadence`, `workflow-contract`, `workspace-bootstrap`, `validate-loop`, `app-validation`, `evidence-protocol`, `ticket-lifecycle`, `observability`, `safety-policy`, `smoke-ticket-eval`.
+Accepted focus names: `cold-start-brief`, `rules-dir`, `api-doc-policy`, `lint-messages`, `pre-commit`, `test-suite`, `pr-review`, `repo-skills`, `gc-cadence`, `workflow-contract`, `workspace-bootstrap`, `validate-loop`, `app-validation`, `evidence-protocol`, `ticket-lifecycle`, `observability`, `safety-policy`, `smoke-ticket-eval`.
 
 Numeric aliases:
 
@@ -44,6 +44,7 @@ Numeric aliases:
 | `focus:6` | `pr-review` |
 | `focus:7` | `repo-skills` |
 | `focus:8` | `gc-cadence` |
+| `focus:api-doc-policy` | `api-doc-policy` |
 | `focus:symphony-1` | `workflow-contract` |
 | `focus:symphony-2` | `workspace-bootstrap` |
 | `focus:symphony-3` | `validate-loop` |
@@ -61,13 +62,25 @@ When the user asks for readiness but also asks you to change files, prefer the m
 For each artifact, score `✅ Present / ⚠️ Partial / ❌ Missing` with concrete path evidence and a one-line gap.
 
 1. **Cold-start brief** — root `AGENTS.md` / `CLAUDE.md` / operator docs. Tells an agent what this is, how to build, how to test, where rules live, and gotchas. Lean, not marketing.
-2. **Rules directory** — per-domain coding standards in `rules/`, `.cursor/rules/`, `docs/rules/`, `docs/solutions/`, etc. Imperative rules with reasoning.
+2. **Rules directory** — per-domain coding standards in `rules/`, `.cursor/rules/`, `docs/rules/`, `docs/solutions/`, etc. Imperative rules with reasoning. For repos with exported APIs, this includes an API documentation policy or ADR.
 3. **Lint config with rich error messages** — ESLint / Biome / SwiftLint / ruff / clippy with custom rules whose messages explain why and how to fix.
 4. **Pre-commit hooks** — Husky / lefthook / pre-commit / native git hooks running formatters, type checks, or targeted tests before push/commit.
 5. **Test suite agents can drive** — one-liner to run tests (`npm test`, `./scripts/test.sh`, `cargo test`, etc.). Fast enough and deterministic enough for agents.
 6. **PR review automation** — CodeRabbit, AI reviewer workflows, persona reviewers, or at minimum CI that gates PRs.
 7. **Repo-scoped skills/prompts** — `.agents/skills/`, `.pi/skills/`, `.claude/skills/`, `.codex/`, `.pi/prompts/`, or package-scoped resources. Prefer 5-10 deep resources over many shallow ones.
 8. **Garbage-collection cadence** — documented recurring loop that converts agent/PR feedback into permanent rules, lints, docs, or skills.
+
+## Cross-cutting API documentation check
+
+When a repo exposes package, library, service, or app APIs that agents edit across package boundaries, inspect API documentation as a first-class harness surface:
+
+- policy: `docs/api-documentation-policy.md`, `rules/api-documentation.md`, or equivalent
+- decision record: `docs/adr/*api*documentation*`, `docs/decisions/*api*documentation*`, or equivalent
+- tooling: TypeDoc, DocC, Sphinx/pdoc, rustdoc, godoc, or stack-native equivalent
+- report/backlog: generated missing-docs report or coverage output that separates existing debt from new regressions
+- commands: one-liners such as `docs:api`, `docs:api:check`, `docs:api:report`, or a documented equivalent
+
+Treat a missing API documentation policy as a high-leverage rules/GC gap for repos with meaningful exported surfaces. Do not require full coverage before policy exists; prefer a baseline report plus a strict command that can be enabled once debt is paid down.
 
 ## Symphony readiness overlay
 
@@ -186,6 +199,7 @@ Focus/fix-template map:
 | --- | --- |
 | `cold-start-brief` | `add-cold-start-brief` |
 | `rules-dir` | `extract-rules-dir` |
+| `api-doc-policy` | `add-api-doc-policy` |
 | `lint-messages` | `add-rich-lint-messages` |
 | `pre-commit` | `setup-pre-commit` |
 | `test-suite` | `wrap-test-runner` |

--- a/skills/harness-audit/references/audit-prompt.md
+++ b/skills/harness-audit/references/audit-prompt.md
@@ -36,8 +36,11 @@ Per-domain coding standards: naming, logging, error handling, DB conventions, au
 - `rules/`, `.cursor/rules/`, `docs/rules/`, `.claude/rules/`
 - `docs/solutions/`, `docs/patterns/`, `docs/guidelines/`
 - `CONTRIBUTING.md`, `UBIQUITOUS_LANGUAGE.md`
+- `docs/api-documentation-policy.md`, `rules/api-documentation.md`, `docs/adr/`, `docs/decisions/`
 
 Are they imperative ("do X, not Y") or descriptive prose? Imperative is far stronger for agents. Flag stale rules (e.g., rules for a stack the project doesn't use anymore).
+
+For repos with exported package/library/service APIs, also check whether API documentation expectations are explicit. A repo can have good style rules but still be weak for agents if it has no policy for which exports need TSDoc/JSDoc/docstrings, no ADR explaining the standard, and no missing-docs report to distinguish baseline debt from new regressions.
 
 ## 3. Lint config with rich error messages
 Find the linter config for this stack (`{{LINT_CONFIG_PATHS}}`). Sample 3-5 custom rules — do their error messages explain *why* and *how to fix*, or are they terse defaults? Stock messages are descriptions; rich messages are remediation prompts.
@@ -66,6 +69,8 @@ Concentration check: 5-10 deep skills > 50 shallow ones. Flag sprawl.
 ## 8. Garbage collection cadence
 This is hard to detect from code alone. Look for: weekly review docs, `CHANGELOG.md` with structured entries, `docs/` folder with retros/postmortems, `.github/ISSUE_TEMPLATE/` for "agent slop" or similar, `docs/decisions/` ADRs. Note any signal that PR feedback gets converted into rules/lints over time.
 
+For API-heavy repos, look for doc debt becoming permanent evidence rather than invisible reviewer feedback: generated API documentation reports, coverage summaries, or a strict command that can fail once the baseline backlog is closed.
+
 # Symphony readiness overlay
 
 When the requested mode is `symphony-readiness` or `audit+fix:symphony`, also use `references/symphony-readiness.md` and score the repo on:
@@ -92,6 +97,24 @@ Also universal:
 - Pi package/resource metadata (`package.json#pi`, `.pi/settings.json`, `.pi/skills`, `.pi/prompts`)
 - Any `.claude/settings.json` with hooks configured?
 - `.mcp.json` — what MCP servers are wired?
+- API documentation policy/ADR/report — especially for exported package APIs and cross-package contracts
+
+# API documentation policy check
+
+When the repo exposes meaningful exported APIs, inspect this as a focused sub-check even if the user did not request it explicitly.
+
+Look for:
+- policy docs: `docs/api-documentation-policy.md`, `rules/api-documentation.md`, `CONTRIBUTING.md` sections, or equivalent
+- decision records: `docs/adr/*api*documentation*`, `docs/decisions/*api*documentation*`, or equivalent
+- tooling/config: `typedoc.json`, `eslint-plugin-jsdoc`, `pydocstyle`, Sphinx/pdoc, rustdoc config, DocC, or stack-native equivalent
+- scripts: `docs:api`, `docs:api:check`, `docs:api:report`, `docs:api:strict`, or documented equivalents
+- baseline report: `docs/api-documentation-report.md`, coverage output, or a generated backlog of undocumented exports
+
+Report these states separately:
+- **Policy missing** — no clear standard for what requires API docs.
+- **Tooling missing** — policy exists but no command can check or report coverage.
+- **Backlog exists** — tooling found missing docs; this is acceptable only if the backlog is visible and not falsely wired as a required green gate.
+- **Strict gate ready** — policy, tooling, and coverage are sufficient to fail new regressions.
 
 # Output format
 

--- a/skills/harness-audit/references/fix-patterns.md
+++ b/skills/harness-audit/references/fix-patterns.md
@@ -84,6 +84,49 @@ Do NOT duplicate rules across files — pick one home, point everywhere else.
 
 ---
 
+## `add-api-doc-policy`
+
+Use when: `focus:api-doc-policy` is requested, or the audit finds a repo with meaningful exported APIs but no API documentation policy, ADR, tooling, or baseline report.
+
+```
+Add the smallest policy/tooling surface that lets agents understand and improve public API documentation without forcing a giant one-shot docstring cleanup.
+
+Universal requirements:
+- Add a policy doc such as `docs/api-documentation-policy.md` or `rules/api-documentation.md`.
+- Add an ADR or decision note such as `docs/adr/0001-api-documentation-policy.md` when the repo already uses ADRs or decision docs.
+- Define what requires docs: exported package APIs, app/server entrypoints consumed by other packages, public types, config schemas, runner/tracker/workspace contracts, and error-prone lifecycle hooks.
+- Define what does not require docs: private helpers, obvious local constants, test-only fixtures, and symbols explicitly marked internal.
+- Explain the allowed internal marker for the stack, such as `@internal` for TSDoc/JSDoc.
+- Add a generated baseline report when a tool can produce one cheaply.
+- Do not wire a strict coverage gate into CI until the baseline backlog is low enough to keep CI actionable.
+
+For TypeScript/Bun repos:
+1. Add TypeDoc if it is not already present.
+2. Add `typedoc.json` using real package/app entrypoints.
+3. Add scripts shaped like:
+   - `docs:api`
+   - `docs:api:check`
+   - `docs:api:report`
+   - `docs:api:strict`
+4. If TypeDoc alone does not give a useful missing-docs backlog, add a small AST-based report script that scans exported top-level declarations and detects leading `/** ... */` comments.
+5. Add generated docs output such as `docs/api/` to `.gitignore`.
+6. Commit the baseline report, not the generated HTML/API site, unless the repo already tracks generated docs.
+
+For other stacks, adapt to the native documentation checker:
+- Python: Sphinx, pdoc, pydocstyle, interrogate, or docstring coverage tooling.
+- Swift: DocC plus SwiftLint documentation rules when useful.
+- Rust: rustdoc, `cargo doc`, and `#![deny(missing_docs)]` only after baseline debt is handled.
+- Go: godoc plus `golint`/staticcheck-style comments where the repo already uses those checks.
+
+Verification:
+- Run the report command and ensure it writes the expected baseline report.
+- Run the non-strict docs check.
+- Run the repo's typecheck/test/verify command if package config changed.
+- Run the strict docs command and treat failure as expected only when the report has known missing docs. State the exact missing count instead of claiming the repo is compliant.
+```
+
+---
+
 ## `add-rich-lint-messages`
 
 Use when: artifact #3 is ⚠️ Partial.
@@ -492,6 +535,8 @@ When running `audit+fix` mode and multiple gaps need fixing:
 - `setup-pre-commit` BEFORE `add-rich-lint-messages` (the second needs the first's lint config in place)
 - `wrap-test-runner` / `add-validate-loop` BEFORE `add-cold-start-brief` (the brief points at validation scripts)
 - `extract-rules-dir` BEFORE `add-rich-lint-messages` (lint messages point at rules)
+- `extract-rules-dir` BEFORE `add-api-doc-policy` when the API policy belongs under the rules directory
+- `add-api-doc-policy` BEFORE `setup-gc-cadence` when the GC routine should track documentation debt
 - `wrap-test-runner` / `add-validate-loop` / `add-disposable-bootstrap` BEFORE `add-workflow-contract` (workflow hooks should reference real commands)
 - `add-evidence-protocol` BEFORE `add-ticket-lifecycle-skill` (ticket skill should link to evidence rules)
 - `add-app-validation` BEFORE `add-ticket-lifecycle-skill` when ticket skill references UI/runtime proof

--- a/skills/harness-audit/references/fix-patterns.md
+++ b/skills/harness-audit/references/fix-patterns.md
@@ -88,7 +88,7 @@ Do NOT duplicate rules across files — pick one home, point everywhere else.
 
 Use when: `focus:api-doc-policy` is requested, or the audit finds a repo with meaningful exported APIs but no API documentation policy, ADR, tooling, or baseline report.
 
-```
+```markdown
 Add the smallest policy/tooling surface that lets agents understand and improve public API documentation without forcing a giant one-shot docstring cleanup.
 
 Universal requirements:

--- a/skills/harness-audit/references/stack-typescript.md
+++ b/skills/harness-audit/references/stack-typescript.md
@@ -9,6 +9,7 @@ Covers: Node, Deno, Bun. Most patterns assume Node + npm/pnpm/yarn or Bun.
 | Lint + format | Biome (single tool, fast) | ESLint + Prettier (more rules, more config) |
 | Test runner | Vitest (TS-native, Vite-compat) | Jest (mature), `bun test` (Bun-native), `node:test` |
 | Type checker | `tsc --noEmit` | tsgo (10× faster, experimental) |
+| API docs | TypeDoc + custom missing-docs report | `eslint-plugin-jsdoc`, API Extractor, package-specific docs |
 | Pre-commit | Husky + lint-staged | lefthook (Go-based, parallel) |
 | E2E | Playwright | Cypress |
 | Package manager | Detect from lockfile | bun.lockb / pnpm-lock.yaml / yarn.lock / package-lock.json |
@@ -27,6 +28,32 @@ Covers: Node, Deno, Bun. Most patterns assume Node + npm/pnpm/yarn or Bun.
 - `jest.config.*` or `jest` key in package.json → Jest
 - `bun test` referenced in package.json scripts → Bun native
 - `node --test` → Node native runner
+
+## API documentation policy checks
+
+For TypeScript repos with exported package APIs, check for:
+
+- `typedoc.json` or `typedoc` config in `package.json`
+- `package.json` scripts such as `docs:api`, `docs:api:check`, `docs:api:report`, or `docs:api:strict`
+- `docs/api-documentation-policy.md` or `rules/api-documentation.md`
+- `docs/adr/*api*documentation*` or `docs/decisions/*api*documentation*`
+- a generated missing-docs report, usually `docs/api-documentation-report.md`
+- optional lint support through `eslint-plugin-jsdoc` or a custom rule when the repo already uses ESLint
+
+Recommended shape for Bun/TypeScript packages:
+
+```json
+{
+  "scripts": {
+    "docs:api": "typedoc --options typedoc.json",
+    "docs:api:check": "typedoc --options typedoc.json --emit none",
+    "docs:api:report": "bun scripts/api-docs-report.ts --write docs/api-documentation-report.md",
+    "docs:api:strict": "bun scripts/api-docs-report.ts --fail-on-missing && typedoc --options typedoc.json --emit none --treatValidationWarningsAsErrors"
+  }
+}
+```
+
+Do not wire `docs:api:strict` into CI while the baseline report still has known debt. The useful first step is making the debt explicit and giving agents a contract for documenting new or changed exports.
 
 ## Pre-commit pattern (bun + Biome)
 
@@ -98,6 +125,7 @@ jobs:
 - **No `noUncheckedIndexedAccess`** — for data-heavy apps (financial, ML), this is a meaningful safety gap even with `strict: true`.
 - **Lockfile committed but ignored in CI** — `bun install` without `--frozen-lockfile` lets versions drift between dev and CI.
 - **Workspaces with no shared tsconfig** — each package has divergent compiler options, agent edits one config and breaks another.
+- **Doc coverage warning treated as mystery failure** — if CodeRabbit or CI flags missing JSDoc/TSDoc, check whether the repo has a policy, ADR, and generated backlog before asking agents to blindly edit every export.
 
 ## Custom rule patterns worth encoding
 
@@ -114,3 +142,4 @@ When auditing custom Biome / ESLint rules, recommend these patterns specifically
 - Package count
 - Path aliases / module resolution custom config
 - Tauri / Electron / Next.js / specific framework hints
+- API documentation contract (`typedoc.json`, `docs:api*` scripts, `docs/api-documentation-policy.md`, ADR/report)


### PR DESCRIPTION
## Summary
- Adds `api-doc-policy` as a first-class harness-audit focus.
- Teaches audits to detect missing API documentation policy, ADRs, tooling, and baseline reports.
- Adds TypeScript/Bun guidance for TypeDoc-backed reports and strict rollout.
- Adds an `add-api-doc-policy` fix template so audit+fix runs can apply the pattern intentionally.

## Changelog
- `skills/harness-audit/SKILL.md`: documents the new focus and cross-cutting API documentation check.
- `skills/harness-audit/references/audit-prompt.md`: adds policy/ADR/report evidence checks and states to report separately.
- `skills/harness-audit/references/stack-typescript.md`: adds TypeDoc/script guidance and CodeRabbit doc coverage warning handling.
- `skills/harness-audit/references/fix-patterns.md`: adds the implementation recipe and sequencing guidance.

## Verification
- `git diff --check`
- `npm run check`

## Review notes
This is docs/skill behavior only. The main thing to review is whether `api-doc-policy` belongs as a cross-cutting focus rather than a ninth baseline artifact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API documentation policy assessment and a dedicated API-doc check to audit workflows
  * Introduced an "add API doc policy" fix pattern and adjusted execution ordering for remediation steps
  * Added TypeScript stack recommendations for API doc tooling and reporting

* **Documentation**
  * Expanded audit prompts and baseline guidance to evaluate API-doc readiness, tooling, reporting, and backlog handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AojdevStudio/agentic-utilities/pull/8)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->