### PR TITLE
Add Conditional Hook config loading and status command

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,6 +16,10 @@ _Avoid_: Search tool when discussing the provider rather than the Pi tool surfac
 The Google Custom Search API key plus Programmable Search Engine ID (`cx`) required to query Google Custom Search JSON API.
 _Avoid_: Google key alone, CSE token.
 
+**Conditional Hook**:
+A user-configured policy that watches Pi events and may run a side-effect command after a matching event.
+_Avoid_: Built-in hook when the behavior comes from JSON config.
+
 **Smart Fetch**:
 A browser-fingerprinted URL fetch and extraction flow that returns agent-usable content rather than just raw HTTP bytes.
 _Avoid_: Web search, crawl.

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -9,6 +9,7 @@ Keep this as the human-readable record of what lives in the package.
 | `anti-hedging` | Extension | `extensions/anti-hedging.ts` | active | Injects concise anti-hedging response guidance for sharper agent answers. |
 | `autopilot` | Extension | `extensions/autopilot/index.ts` | active | Autopilot workflow extension with approvals, preferences, continuation manifests, v2 workflow support, and command docs in `docs/autopilot.md`. |
 | `bash-guard` | Extension | `extensions/bash-guard/index.ts` | active | Prompts before risky bash commands, blocks catastrophic subagent commands, and guards sensitive read/write/edit paths with optional JSON policy files. |
+| `conditional-hooks` | Extension | `extensions/conditional-hooks/index.ts` | active | Loads Conditional Hook JSON config, merges global and trusted-project hook policy, and reports active/disabled hooks through `/conditional-hooks`. |
 | `hello` | Extension | `extensions/hello/index.ts` | example | Smoke-test extension that exposes `/agentic-utilities` and `agentic_utilities_ping`. |
 | `interactive-artifacts` | Extension | `extensions/interactive-artifacts/index.ts` | active | Publishes browser-based interactive concept explainer artifacts from Pi. |
 | `question` | Extension | `extensions/question.ts` | active | Adds interactive single-question and batch-question UI tools. |

--- a/extensions/conditional-hooks/index.ts
+++ b/extensions/conditional-hooks/index.ts
@@ -1,0 +1,267 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+export type ConditionalHook = {
+  name: string;
+  enabled?: boolean;
+  events?: string[];
+  when?: Record<string, unknown>;
+  run?: Record<string, unknown>;
+};
+
+type ConditionalHooksFile = {
+  hooks: ConditionalHook[];
+};
+
+export type ConfigSourceStatus = {
+  label: "global" | "project";
+  path: string;
+  status: "missing" | "skipped" | "loaded" | "invalid";
+  hookNames: string[];
+};
+
+export type ConditionalHooksState = {
+  sources: ConfigSourceStatus[];
+  activeHooks: ConditionalHook[];
+  disabledHooks: ConditionalHook[];
+  warnings: string[];
+};
+
+type LoadOptions = {
+  globalPath?: string;
+  projectPath?: string;
+};
+
+const CONFIG_BASENAME = "conditional-hooks.json";
+let latestState: ConditionalHooksState = emptyState();
+
+function emptyState(): ConditionalHooksState {
+  return {
+    sources: [],
+    activeHooks: [],
+    disabledHooks: [],
+    warnings: [],
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateHook(value: unknown, sourcePath: string, index: number, warnings: string[]): ConditionalHook | null {
+  if (!isRecord(value)) {
+    warnings.push(`${sourcePath}: hooks[${index}] must be an object.`);
+    return null;
+  }
+
+  if (typeof value.name !== "string" || value.name.trim() === "") {
+    warnings.push(`${sourcePath}: hooks[${index}].name must be a non-empty string.`);
+    return null;
+  }
+
+  if ("enabled" in value && typeof value.enabled !== "boolean") {
+    warnings.push(`${sourcePath}: hook "${value.name}" enabled must be a boolean when present.`);
+    return null;
+  }
+
+  if ("events" in value) {
+    if (
+      !Array.isArray(value.events) ||
+      value.events.some((event) => typeof event !== "string" || event.trim() === "")
+    ) {
+      warnings.push(`${sourcePath}: hook "${value.name}" events must be an array of non-empty strings when present.`);
+      return null;
+    }
+  }
+
+  if ("when" in value && !isRecord(value.when)) {
+    warnings.push(`${sourcePath}: hook "${value.name}" when must be an object when present.`);
+    return null;
+  }
+
+  if ("run" in value && !isRecord(value.run)) {
+    warnings.push(`${sourcePath}: hook "${value.name}" run must be an object when present.`);
+    return null;
+  }
+
+  return {
+    ...value,
+    name: value.name.trim(),
+    enabled: typeof value.enabled === "boolean" ? value.enabled : undefined,
+    events: Array.isArray(value.events) ? [...value.events] : undefined,
+    when: isRecord(value.when) ? { ...value.when } : undefined,
+    run: isRecord(value.run) ? { ...value.run } : undefined,
+  };
+}
+
+function readHooksFile(sourcePath: string, warnings: string[]): ConditionalHooksFile | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(sourcePath, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warnings.push(`${sourcePath}: unable to read config: ${message}`);
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warnings.push(`${sourcePath}: invalid strict JSON: ${message}`);
+    return null;
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.hooks)) {
+    warnings.push(`${sourcePath}: config must be a JSON object with a hooks array.`);
+    return null;
+  }
+
+  const hooks = parsed.hooks
+    .map((hook, index) => validateHook(hook, sourcePath, index, warnings))
+    .filter((hook): hook is ConditionalHook => hook !== null);
+
+  return { hooks };
+}
+
+function loadSource(
+  label: "global" | "project",
+  sourcePath: string,
+  warnings: string[],
+): {
+  source: ConfigSourceStatus;
+  hooks: ConditionalHook[];
+} {
+  try {
+    fs.statSync(sourcePath);
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? (error as { code?: unknown }).code : undefined;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return {
+        source: { label, path: sourcePath, status: "missing", hookNames: [] },
+        hooks: [],
+      };
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    warnings.push(`${sourcePath}: unable to read config: ${message}`);
+    return {
+      source: { label, path: sourcePath, status: "invalid", hookNames: [] },
+      hooks: [],
+    };
+  }
+
+  const loaded = readHooksFile(sourcePath, warnings);
+  if (!loaded) {
+    return {
+      source: { label, path: sourcePath, status: "invalid", hookNames: [] },
+      hooks: [],
+    };
+  }
+
+  return {
+    source: { label, path: sourcePath, status: "loaded", hookNames: loaded.hooks.map((hook) => hook.name) },
+    hooks: loaded.hooks,
+  };
+}
+
+export function loadConditionalHooksState(
+  cwd: string,
+  projectTrusted: boolean,
+  options: LoadOptions = {},
+): ConditionalHooksState {
+  const warnings: string[] = [];
+  const sources: ConfigSourceStatus[] = [];
+  const merged = new Map<string, ConditionalHook>();
+
+  const globalPath = options.globalPath ?? path.join(os.homedir(), ".pi", "agent", CONFIG_BASENAME);
+  const globalSource = loadSource("global", globalPath, warnings);
+  sources.push(globalSource.source);
+  for (const hook of globalSource.hooks) merged.set(hook.name, hook);
+
+  const projectPath = options.projectPath ?? path.join(cwd, ".pi", CONFIG_BASENAME);
+  if (projectTrusted) {
+    const projectSource = loadSource("project", projectPath, warnings);
+    sources.push(projectSource.source);
+    for (const hook of projectSource.hooks) merged.set(hook.name, hook);
+  } else {
+    sources.push({ label: "project", path: projectPath, status: "skipped", hookNames: [] });
+  }
+
+  const hooks = Array.from(merged.values()).sort((a, b) => a.name.localeCompare(b.name));
+  return {
+    sources,
+    activeHooks: hooks.filter((hook) => hook.enabled !== false),
+    disabledHooks: hooks.filter((hook) => hook.enabled === false),
+    warnings,
+  };
+}
+
+function isProjectTrusted(ctx: ExtensionContext): boolean {
+  const candidate = ctx as ExtensionContext & {
+    isProjectTrusted?: () => boolean;
+    settingsManager?: { isProjectTrusted?: () => boolean };
+  };
+
+  const trustReaders: Array<{ fn: (() => boolean) | undefined; receiver: unknown }> = [
+    { fn: candidate.isProjectTrusted, receiver: candidate },
+    { fn: candidate.settingsManager?.isProjectTrusted, receiver: candidate.settingsManager },
+  ];
+
+  for (const { fn, receiver } of trustReaders) {
+    if (!fn) continue;
+    try {
+      if (fn.call(receiver) === true) return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+function formatNames(hooks: ConditionalHook[]): string {
+  return hooks.length ? hooks.map((hook) => hook.name).join(", ") : "(none)";
+}
+
+export function formatConditionalHooksStatus(state: ConditionalHooksState): string {
+  const lines = [
+    "Conditional Hook status",
+    "",
+    "Config sources:",
+    ...state.sources.map((source) => {
+      const hooks = source.hookNames.length ? ` [${source.hookNames.join(", ")}]` : "";
+      return `- ${source.label}: ${source.status} ${source.path}${hooks}`;
+    }),
+    "",
+    `Active hooks: ${formatNames(state.activeHooks)}`,
+    `Disabled hooks: ${formatNames(state.disabledHooks)}`,
+    "",
+    "Warnings:",
+    ...(state.warnings.length ? state.warnings.map((warning) => `- ${warning}`) : ["- (none)"]),
+  ];
+
+  return lines.join("\n");
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    latestState = loadConditionalHooksState(ctx.cwd, isProjectTrusted(ctx));
+  });
+
+  pi.registerCommand("conditional-hooks", {
+    description: "Show Conditional Hook config sources, hooks, and warnings.",
+    handler: async (_args, ctx) => {
+      latestState = loadConditionalHooksState(ctx.cwd, isProjectTrusted(ctx));
+      const message = formatConditionalHooksStatus(latestState);
+      if (ctx.hasUI) {
+        ctx.ui.notify(message, latestState.warnings.length ? "warning" : "info");
+      } else {
+        console.log(message);
+      }
+    },
+  });
+}

--- a/extensions/conditional-hooks/smoke-test.mjs
+++ b/extensions/conditional-hooks/smoke-test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createJiti } from "@mariozechner/jiti";
+
+const jiti = createJiti(import.meta.url);
+const conditionalHooks = await jiti.import("./index.ts");
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2), "utf8");
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "conditional-hooks-"));
+try {
+  const cwd = path.join(tmp, "repo");
+  const globalPath = path.join(tmp, "home", ".pi", "agent", "conditional-hooks.json");
+  const projectPath = path.join(cwd, ".pi", "conditional-hooks.json");
+  fs.mkdirSync(cwd, { recursive: true });
+
+  writeJson(globalPath, {
+    hooks: [
+      { name: "global-active", enabled: true, events: ["tool_result"], when: {}, run: {} },
+      { name: "overridden", enabled: true, events: ["tool_result"], when: {}, run: {} },
+    ],
+  });
+  writeJson(projectPath, {
+    hooks: [
+      { name: "overridden", enabled: false, events: ["tool_result"], when: {}, run: {} },
+      { name: "project-active", enabled: true, events: ["tool_result"], when: {}, run: {} },
+    ],
+  });
+
+  const untrusted = conditionalHooks.loadConditionalHooksState(cwd, false, { globalPath, projectPath });
+  assert.deepEqual(
+    untrusted.activeHooks.map((hook) => hook.name),
+    ["global-active", "overridden"],
+    "untrusted project config must not add or override hooks",
+  );
+  assert.deepEqual(untrusted.disabledHooks, [], "untrusted project disable must be ignored");
+  assert.equal(untrusted.sources.find((source) => source.label === "project")?.status, "skipped");
+
+  const trusted = conditionalHooks.loadConditionalHooksState(cwd, true, { globalPath, projectPath });
+  assert.deepEqual(
+    trusted.activeHooks.map((hook) => hook.name),
+    ["global-active", "project-active"],
+    "trusted project config adds hooks and disables same-named globals",
+  );
+  assert.deepEqual(
+    trusted.disabledHooks.map((hook) => hook.name),
+    ["overridden"],
+  );
+
+  fs.writeFileSync(projectPath, "{ bad json", "utf8");
+  const invalid = conditionalHooks.loadConditionalHooksState(cwd, true, { globalPath, projectPath });
+  assert.equal(invalid.sources.find((source) => source.label === "project")?.status, "invalid");
+  assert.match(invalid.warnings.join("\n"), /invalid strict JSON/);
+  assert.match(conditionalHooks.formatConditionalHooksStatus(invalid), /Warnings:/);
+
+  fs.rmSync(globalPath, { force: true });
+  fs.mkdirSync(globalPath, { recursive: true });
+  const unreadable = conditionalHooks.loadConditionalHooksState(cwd, false, { globalPath, projectPath });
+  assert.equal(unreadable.sources.find((source) => source.label === "global")?.status, "invalid");
+  assert.match(unreadable.warnings.join("\n"), /unable to read config/);
+
+  const registered = { events: new Map(), commands: new Map() };
+  const fakePi = {
+    on(eventName, handler) {
+      registered.events.set(eventName, handler);
+    },
+    registerCommand(commandName, config) {
+      registered.commands.set(commandName, config);
+    },
+  };
+  conditionalHooks.default(fakePi);
+  assert.equal(typeof registered.events.get("session_start"), "function");
+  assert.equal(typeof registered.commands.get("conditional-hooks")?.handler, "function");
+
+  const commandCwd = path.join(tmp, "command-repo");
+  const commandProjectPath = path.join(commandCwd, ".pi", "conditional-hooks.json");
+  fs.mkdirSync(commandCwd, { recursive: true });
+  writeJson(commandProjectPath, {
+    hooks: [{ name: "trusted-command-hook", enabled: true, events: ["tool_result"], when: {}, run: {} }],
+  });
+
+  let logged = "";
+  const originalLog = console.log;
+  console.log = (message) => {
+    logged = String(message);
+  };
+  try {
+    await registered.commands.get("conditional-hooks").handler("", {
+      cwd: commandCwd,
+      hasUI: false,
+      isProjectTrusted: () => true,
+    });
+  } finally {
+    console.log = originalLog;
+  }
+  assert.match(logged, /project: loaded/);
+  assert.match(logged, /trusted-command-hook/);
+
+  console.log("conditional-hooks smoke tests passed");
+} finally {
+  fs.rmSync(tmp, { recursive: true, force: true });
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint": "biome lint .",
     "lint:fix": "biome check --write .",
     "prepare": "husky",
-    "test": "node extensions/autopilot/v2-smoke-test.mjs",
+    "test": "node extensions/autopilot/v2-smoke-test.mjs && node extensions/conditional-hooks/smoke-test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {


### PR DESCRIPTION
Closes #17

## Acceptance criteria

- [x] `extensions/conditional-hooks/index.ts` exists and exports `default function (pi: ExtensionAPI)` using `@mariozechner/pi-coding-agent` imports.
- [x] The extension loads strict JSON from the global config path and from trusted project config only when `ctx.isProjectTrusted()` is true.
- [x] Hook configs merge by `name`, including project `enabled: false` disabling a same-named global hook.
- [x] Invalid or unreadable config produces a warning visible in `/conditional-hooks` and does not crash startup/reload.
- [x] `/conditional-hooks` reports config sources, active hooks, disabled hooks, and warnings.
- [x] `docs/catalog.md` includes the new extension.
- [x] `npm run typecheck` passes.

## Functional evidence

```bash
npm run check
# ✓ lint, typecheck, smoke tests, plugin validation, resource inventory passed

pi --no-extensions -e extensions/conditional-hooks/index.ts --no-tools --offline -p "/conditional-hooks"
# project: skipped .pi/conditional-hooks.json
# Active hooks: (none)

pi --no-extensions -e extensions/conditional-hooks/index.ts --no-tools --offline --approve -p "/conditional-hooks"
# project: loaded .pi/conditional-hooks.json [project-check]
# Active hooks: project-check
```

## Self-review

- Scope stays inside issue #17: config loading, merge/status reporting, docs/catalog, tests only.
- No hook execution, tool-event matching, worktree-GC docs, or install verification added.
- Reviewer subagents ran multiple passes; final pass returned `ready`.
- LSP diagnostics for `extensions/conditional-hooks/index.ts`: no diagnostics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Conditional Hooks extension enabling event-monitoring policies with configurable side-effect commands; supports global and project-level configuration with new status command

* **Documentation**
  * Added glossary definition and resource catalog entry for Conditional Hooks

* **Tests**
  * Added smoke tests for Conditional Hooks extension functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->