### PR TITLE
Run matching agent bash Conditional Hooks safely

### DIFF
--- a/extensions/conditional-hooks/index.ts
+++ b/extensions/conditional-hooks/index.ts
@@ -7,8 +7,25 @@ export type ConditionalHook = {
   name: string;
   enabled?: boolean;
   events?: string[];
-  when?: Record<string, unknown>;
-  run?: Record<string, unknown>;
+  when?: ConditionalHookWhen;
+  run?: ConditionalHookRun;
+  runOnError?: boolean;
+};
+
+export type ConditionalHookWhen = {
+  toolName?: { regex?: string };
+  command?: { regex?: string };
+  repoContains?: string;
+  [key: string]: unknown;
+};
+
+export type ConditionalHookRun = {
+  command?: string;
+  cwd?: "repoRoot" | string;
+  timeout?: number;
+  ignoreFailure?: boolean;
+  runOnError?: boolean;
+  [key: string]: unknown;
 };
 
 type ConditionalHooksFile = {
@@ -32,6 +49,21 @@ export type ConditionalHooksState = {
 type LoadOptions = {
   globalPath?: string;
   projectPath?: string;
+};
+
+type ExecLike = (
+  command: string,
+  args: string[],
+  options?: { cwd?: string; timeout?: number },
+) => Promise<{ stdout?: string; stderr?: string; code?: number; exitCode?: number; killed?: boolean }>;
+
+type WarningSink = (warning: string, hook: ConditionalHook) => void | Promise<void>;
+
+type BashSource = {
+  toolName: string;
+  command: string;
+  cwd: string;
+  isError: boolean;
 };
 
 const CONFIG_BASENAME = "conditional-hooks.json";
@@ -86,6 +118,11 @@ function validateHook(value: unknown, sourcePath: string, index: number, warning
     return null;
   }
 
+  if ("runOnError" in value && typeof value.runOnError !== "boolean") {
+    warnings.push(`${sourcePath}: hook "${value.name}" runOnError must be a boolean when present.`);
+    return null;
+  }
+
   return {
     ...value,
     name: value.name.trim(),
@@ -93,6 +130,7 @@ function validateHook(value: unknown, sourcePath: string, index: number, warning
     events: Array.isArray(value.events) ? [...value.events] : undefined,
     when: isRecord(value.when) ? { ...value.when } : undefined,
     run: isRecord(value.run) ? { ...value.run } : undefined,
+    runOnError: typeof value.runOnError === "boolean" ? value.runOnError : undefined,
   };
 }
 
@@ -227,6 +265,119 @@ function formatNames(hooks: ConditionalHook[]): string {
   return hooks.length ? hooks.map((hook) => hook.name).join(", ") : "(none)";
 }
 
+export function extractBashSource(event: unknown, ctxCwd?: string): BashSource | null {
+  const record = isRecord(event) ? event : {};
+  const toolName = typeof record.toolName === "string" ? record.toolName : "";
+  if (!isBashLikeToolName(toolName)) return null;
+
+  const input = isRecord(record.input) ? record.input : undefined;
+  const args = isRecord(record.args) ? record.args : undefined;
+  const toolInput = isRecord(record.tool_input) ? record.tool_input : undefined;
+
+  const command = firstString(input?.command, args?.command, toolInput?.command);
+  if (!command) return null;
+
+  return {
+    toolName,
+    command,
+    cwd: firstString(input?.cwd, args?.cwd, toolInput?.cwd, ctxCwd, ".") ?? ".",
+    isError: record.isError === true,
+  };
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim() !== "") return value;
+  }
+  return undefined;
+}
+
+function isBashLikeToolName(toolName: string): boolean {
+  return toolName === "bash" || toolName === "Bash" || toolName.endsWith(".bash");
+}
+
+function regexMatches(pattern: string | undefined, value: string): boolean {
+  if (!pattern) return true;
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return false;
+  }
+}
+
+async function resolveRepoRoot(cwd: string, exec: ExecLike): Promise<string | null> {
+  try {
+    const result = await exec("git", ["-C", cwd, "rev-parse", "--show-toplevel"], { timeout: 10_000 });
+    const repoRoot = String(result.stdout ?? "").trim();
+    return repoRoot || null;
+  } catch {
+    return null;
+  }
+}
+
+async function hookMatchesSource(
+  hook: ConditionalHook,
+  source: BashSource,
+  exec: ExecLike,
+): Promise<{ matches: boolean; repoRoot: string | null }> {
+  if (!hook.events?.includes("tool_result")) return { matches: false, repoRoot: null };
+
+  const runOnError = hook.runOnError === true || hook.run?.runOnError === true;
+  if (source.isError && !runOnError) return { matches: false, repoRoot: null };
+
+  if (!regexMatches(hook.when?.toolName?.regex, source.toolName)) return { matches: false, repoRoot: null };
+  if (!regexMatches(hook.when?.command?.regex, source.command)) return { matches: false, repoRoot: null };
+
+  if (hook.when?.repoContains) {
+    const repoRoot = await resolveRepoRoot(source.cwd, exec);
+    if (!repoRoot) return { matches: false, repoRoot: null };
+    if (!fs.existsSync(path.join(repoRoot, hook.when.repoContains))) return { matches: false, repoRoot };
+    return { matches: true, repoRoot };
+  }
+
+  return { matches: true, repoRoot: null };
+}
+
+export async function runMatchingConditionalHooks(options: {
+  hooks: ConditionalHook[];
+  event: unknown;
+  ctxCwd?: string;
+  exec: ExecLike;
+  warn?: WarningSink;
+}): Promise<void> {
+  const source = extractBashSource(options.event, options.ctxCwd);
+  if (!source) return;
+
+  for (const hook of options.hooks) {
+    const { matches, repoRoot } = await hookMatchesSource(hook, source, options.exec);
+    if (!matches) continue;
+
+    const command = hook.run?.command;
+    if (typeof command !== "string" || command.trim() === "") continue;
+
+    const cwd =
+      hook.run?.cwd === "repoRoot"
+        ? (repoRoot ?? (await resolveRepoRoot(source.cwd, options.exec)) ?? source.cwd)
+        : source.cwd;
+    try {
+      const result = await options.exec("sh", ["-lc", command], { cwd, timeout: hook.run?.timeout });
+      const exitCode = typeof result.code === "number" ? result.code : result.exitCode;
+      if (exitCode && exitCode !== 0) {
+        if (hook.run?.ignoreFailure === true) continue;
+        const stderr = String(result.stderr ?? "").trim();
+        await options.warn?.(
+          `Conditional Hook "${hook.name}" failed with exit code ${exitCode}${stderr ? `: ${stderr}` : ""}`,
+          hook,
+        );
+      }
+    } catch (error) {
+      if (hook.run?.ignoreFailure === true) continue;
+      const message = error instanceof Error ? error.message : String(error);
+      await options.warn?.(`Conditional Hook "${hook.name}" failed: ${message}`, hook);
+    }
+  }
+}
+
 export function formatConditionalHooksStatus(state: ConditionalHooksState): string {
   const lines = [
     "Conditional Hook status",
@@ -250,6 +401,25 @@ export function formatConditionalHooksStatus(state: ConditionalHooksState): stri
 export default function (pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     latestState = loadConditionalHooksState(ctx.cwd, isProjectTrusted(ctx));
+  });
+
+  pi.on("tool_result", async (event, ctx) => {
+    await runMatchingConditionalHooks({
+      hooks: latestState.activeHooks,
+      event,
+      ctxCwd: ctx.cwd,
+      exec: (command, args, options) => pi.exec(command, args, options as any),
+      warn: async (warning, hook) => {
+        latestState.warnings.push(warning);
+        if (ctx.hasUI) ctx.ui.notify(warning, "warning");
+        pi.sendMessage({
+          customType: "conditional-hook-warning",
+          content: warning,
+          display: true,
+          details: { hook: hook.name, timestamp: Date.now() },
+        });
+      },
+    });
   });
 
   pi.registerCommand("conditional-hooks", {

--- a/extensions/conditional-hooks/smoke-test.mjs
+++ b/extensions/conditional-hooks/smoke-test.mjs
@@ -101,6 +101,238 @@ try {
   assert.match(logged, /project: loaded/);
   assert.match(logged, /trusted-command-hook/);
 
+  const mergeRegex = "\\bgh\\s+pr\\s+merge\\b|\\bgit\\s+merge(?!-)\\b";
+  const bashHook = {
+    name: "bash-hook",
+    enabled: true,
+    events: ["tool_result"],
+    when: {
+      toolName: { regex: "(^|\\.)bash$|^Bash$" },
+      command: { regex: mergeRegex },
+    },
+    run: { command: "echo hook", ignoreFailure: true },
+  };
+
+  async function runHookScenario({ event, hooks = [bashHook], repoRoot, failShell = false }) {
+    const calls = [];
+    const warnings = [];
+    const exec = async (command, args, options = {}) => {
+      calls.push({ command, args, options });
+      if (command === "git") {
+        if (!repoRoot) throw new Error("not a git repo");
+        return { stdout: `${repoRoot}\n` };
+      }
+      if (command === "sh" && failShell) return { stdout: "", stderr: "hook failed", code: 1 };
+      return { stdout: "hook output\n", stderr: "", code: 0 };
+    };
+    await conditionalHooks.runMatchingConditionalHooks({
+      hooks,
+      event,
+      ctxCwd: cwd,
+      exec,
+      warn: (warning) => warnings.push(warning),
+    });
+    return { calls, warnings };
+  }
+
+  for (const toolName of ["bash", "Bash", "functions.bash"]) {
+    const { calls } = await runHookScenario({
+      event: { type: "tool_result", toolName, input: { command: "git merge --ff-only HEAD", cwd }, isError: false },
+    });
+    assert.equal(
+      calls.some((call) => call.command === "sh"),
+      true,
+      `${toolName} should trigger bash hook`,
+    );
+  }
+
+  const ghMerge = await runHookScenario({
+    event: {
+      type: "tool_result",
+      toolName: "bash",
+      input: { command: "gh pr merge 123 --squash", cwd },
+      isError: false,
+    },
+  });
+  assert.equal(
+    ghMerge.calls.some((call) => call.command === "sh"),
+    true,
+    "gh pr merge should trigger",
+  );
+
+  const argsCommand = await runHookScenario({
+    event: {
+      type: "tool_result",
+      toolName: "bash",
+      args: { command: "git merge --ff-only HEAD", cwd },
+      isError: false,
+    },
+  });
+  assert.equal(
+    argsCommand.calls.some((call) => call.command === "sh"),
+    true,
+    "event.args.command should trigger",
+  );
+
+  const toolInputCommand = await runHookScenario({
+    event: {
+      type: "tool_result",
+      toolName: "bash",
+      tool_input: { command: "git merge --ff-only HEAD", cwd },
+      isError: false,
+    },
+  });
+  assert.equal(
+    toolInputCommand.calls.some((call) => call.command === "sh"),
+    true,
+    "event.tool_input.command should trigger",
+  );
+
+  const toolInputCwd = path.join(tmp, "tool-input-cwd");
+  const toolInputCwdResult = await runHookScenario({
+    event: {
+      type: "tool_result",
+      toolName: "bash",
+      tool_input: { command: "git merge --ff-only HEAD", cwd: toolInputCwd },
+      isError: false,
+    },
+  });
+  assert.equal(
+    toolInputCwdResult.calls.find((call) => call.command === "sh")?.options.cwd,
+    toolInputCwd,
+    "event.tool_input.cwd should be used when input/args cwd are absent",
+  );
+
+  for (const command of ["git merge-base --is-ancestor HEAD origin/main", "ls"]) {
+    const { calls } = await runHookScenario({
+      event: { type: "tool_result", toolName: "bash", input: { command, cwd }, isError: false },
+    });
+    assert.equal(
+      calls.some((call) => call.command === "sh"),
+      false,
+      `${command} should not trigger`,
+    );
+  }
+
+  const nonBash = await runHookScenario({
+    event: {
+      type: "tool_result",
+      toolName: "read",
+      input: { command: "git merge --ff-only HEAD", cwd },
+      isError: false,
+    },
+  });
+  assert.equal(nonBash.calls.length, 0, "non-bash tools must not trigger bash hooks");
+
+  const repoRoot = path.join(tmp, "repo-root");
+  const repoHook = {
+    ...bashHook,
+    name: "repo-hook",
+    when: { ...bashHook.when, repoContains: "scripts/worktree-gc.ts" },
+    run: { command: "pwd", cwd: "repoRoot", ignoreFailure: true },
+  };
+  const outsideRepo = await runHookScenario({
+    hooks: [repoHook],
+    event: {
+      type: "tool_result",
+      toolName: "bash",
+      input: { command: "git merge --ff-only HEAD", cwd },
+      isError: false,
+    },
+  });
+  assert.equal(
+    outsideRepo.calls.some((call) => call.command === "sh"),
+    false,
+    "repoContains skips outside repos",
+  );
+
+  fs.mkdirSync(repoRoot, { recursive: true });
+  const missingRepoFile = await runHookScenario({
+    hooks: [repoHook],
+    repoRoot,
+    event: {
+      type: "tool_result",
+      toolName: "bash",
+      input: { command: "git merge --ff-only HEAD", cwd },
+      isError: false,
+    },
+  });
+  assert.equal(
+    missingRepoFile.calls.some((call) => call.command === "sh"),
+    false,
+    "repoContains skips missing files",
+  );
+
+  fs.mkdirSync(path.join(repoRoot, "scripts"), { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, "scripts", "worktree-gc.ts"), "", "utf8");
+  const repoMatch = await runHookScenario({
+    hooks: [repoHook],
+    repoRoot,
+    event: {
+      type: "tool_result",
+      toolName: "bash",
+      input: { command: "git merge --ff-only HEAD", cwd },
+      isError: false,
+    },
+  });
+  const shellCall = repoMatch.calls.find((call) => call.command === "sh");
+  assert.equal(shellCall?.options.cwd, repoRoot, "run.cwd repoRoot should run from resolved git root");
+
+  const defaultErrorSkip = await runHookScenario({
+    event: {
+      type: "tool_result",
+      toolName: "bash",
+      input: { command: "git merge --ff-only HEAD", cwd },
+      isError: true,
+    },
+  });
+  assert.equal(
+    defaultErrorSkip.calls.some((call) => call.command === "sh"),
+    false,
+    "failed source skips by default",
+  );
+
+  const runOnError = await runHookScenario({
+    hooks: [{ ...bashHook, runOnError: true }],
+    event: {
+      type: "tool_result",
+      toolName: "bash",
+      input: { command: "git merge --ff-only HEAD", cwd },
+      isError: true,
+    },
+  });
+  assert.equal(
+    runOnError.calls.some((call) => call.command === "sh"),
+    true,
+    "runOnError true runs after failed source",
+  );
+
+  const failingEvent = {
+    type: "tool_result",
+    toolName: "bash",
+    input: { command: "git merge --ff-only HEAD", cwd },
+    isError: false,
+  };
+  const swallowedFailure = await runHookScenario({
+    hooks: [{ ...bashHook, run: { command: "exit 1", ignoreFailure: true } }],
+    event: {
+      type: "tool_result",
+      toolName: "bash",
+      input: { command: "git merge --ff-only HEAD", cwd },
+      isError: false,
+    },
+    failShell: true,
+  });
+  assert.deepEqual(swallowedFailure.warnings, [], "ignoreFailure true should swallow hook failures");
+
+  const failure = await runHookScenario({
+    hooks: [{ ...bashHook, run: { command: "exit 1", ignoreFailure: false } }],
+    event: failingEvent,
+    failShell: true,
+  });
+  assert.equal(failingEvent.isError, false, "hook failure must not mutate original result isError");
+  assert.match(failure.warnings.join("\n"), /Conditional Hook "bash-hook" failed/);
+
   console.log("conditional-hooks smoke tests passed");
 } finally {
   fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
Closes #18

## Acceptance criteria

- [x] A hook with `toolName` regex matching `bash`, `Bash`, or `functions.bash` can run from a `tool_result` event.
- [x] Command regex matching accepts `git merge --ff-only HEAD` and `gh pr merge 123 --squash`.
- [x] Command regex matching rejects `git merge-base --is-ancestor HEAD origin/main` and `ls`.
- [x] Non-bash tools do not trigger bash hooks.
- [x] `repoContains` skips outside git repos and skips repos missing the configured file.
- [x] `run.cwd: "repoRoot"` runs from the resolved git root.
- [x] Hook failures never alter the original tool result `isError` value.
- [x] Success-only default and `runOnError: true` are covered by tests.
- [x] `npm test` and `npm run typecheck` pass.

## Functional evidence

```bash
npm run check
# ✓ lint, typecheck, smoke tests, plugin validation, resource inventory passed
```

Smoke coverage exercises matching, command/cwd extraction fallbacks, repo root lookup, shell execution, nonzero exit warnings, `ignoreFailure`, and `runOnError`.

## Self-review

- Scope stays inside issue #18: hook matching/execution only.
- No stdout appending, `tool_execution_end` fallback, user-bash support, or built-in worktree-GC behavior added.
- Reviewer subagent pass returned `Ready — no blockers`.
