### PR TITLE
Document worktree-GC Conditional Hook config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 | Resource | Type | Purpose |
 | --- | --- | --- |
 | [`autopilot`](extensions/autopilot/) | Pi Extension | Approval-gated workflow runner with continuation manifests and v2 flow. |
+| [`conditional-hooks`](extensions/conditional-hooks/) | Pi Extension | Loads explicit JSON hook policy, including the documented worktree-GC-on-merge example. |
 | [`bambu-slicer`](skills/bambu-slicer/) · [plugin](claude-code/plugins/bambu-slicer/) | Skill + Claude Code plugin | End-to-end Bambu Lab pipeline: OpenSCAD design, MakerWorld browsing, OrcaSlicer-backed STL→3MF, plate arrangement, printer control. |
 | [`harness-audit`](skills/harness-audit/) | Skill (global-first) | Audits a repo for AI-harness readiness across the 10-artifact stack and dispatches surgical fixes. |
 | [`scaffold-notes`](skills/scaffold-notes/) | Skill | Maintenance helper for adding resources to this repo consistently. |
@@ -39,6 +40,8 @@ pi install -l .            # install into the current project's .pi/settings.jso
 ```
 
 After edits inside a running Pi session, run `/reload`.
+
+For Conditional Hooks, put global config in `~/.pi/agent/conditional-hooks.json` or trusted project config in `.pi/conditional-hooks.json`; see [`extensions/conditional-hooks/README.md`](extensions/conditional-hooks/README.md).
 
 Once published:
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -9,7 +9,7 @@ Keep this as the human-readable record of what lives in the package.
 | `anti-hedging` | Extension | `extensions/anti-hedging.ts` | active | Injects concise anti-hedging response guidance for sharper agent answers. |
 | `autopilot` | Extension | `extensions/autopilot/index.ts` | active | Autopilot workflow extension with approvals, preferences, continuation manifests, v2 workflow support, and command docs in `docs/autopilot.md`. |
 | `bash-guard` | Extension | `extensions/bash-guard/index.ts` | active | Prompts before risky bash commands, blocks catastrophic subagent commands, and guards sensitive read/write/edit paths with optional JSON policy files. |
-| `conditional-hooks` | Extension | `extensions/conditional-hooks/index.ts` | active | Loads Conditional Hook JSON config, merges global and trusted-project hook policy, and reports active/disabled hooks through `/conditional-hooks`. |
+| `conditional-hooks` | Extension | `extensions/conditional-hooks/index.ts` | active | Loads Conditional Hook JSON config, merges global and trusted-project hook policy, runs matching bash hooks, appends configured output, and documents explicit worktree-GC-on-merge config. |
 | `hello` | Extension | `extensions/hello/index.ts` | example | Smoke-test extension that exposes `/agentic-utilities` and `agentic_utilities_ping`. |
 | `interactive-artifacts` | Extension | `extensions/interactive-artifacts/index.ts` | active | Publishes browser-based interactive concept explainer artifacts from Pi. |
 | `question` | Extension | `extensions/question.ts` | active | Adds interactive single-question and batch-question UI tools. |

--- a/extensions/conditional-hooks/README.md
+++ b/extensions/conditional-hooks/README.md
@@ -1,0 +1,77 @@
+# conditional-hooks
+
+`conditional-hooks` is a generic Pi Extension for user-configured **Conditional Hook** policy. It loads strict JSON config, reports what it found through `/conditional-hooks`, and runs only hooks that users explicitly configure.
+
+The package does **not** hardcode worktree cleanup or any other hook behavior.
+
+## Config locations
+
+Use one or both config files:
+
+- Global user config: `~/.pi/agent/conditional-hooks.json`
+- Trusted project config: `.pi/conditional-hooks.json`
+
+Project config is read only when the project is trusted by Pi. Project hooks merge by `name`: a trusted project config can add a hook, override a global hook with the same name, or disable a global hook by setting `enabled: false`.
+
+Config must be strict JSON: no comments, no trailing commas, quoted property names, and valid JSON strings.
+
+## Status command
+
+Run:
+
+```text
+/conditional-hooks
+```
+
+The command reports loaded config sources, active hook names, disabled hook names, and parse/validation warnings. Invalid or unreadable config does not crash Pi; it appears as a warning.
+
+## Worktree-GC example
+
+Place this JSON in `~/.pi/agent/conditional-hooks.json` or in a trusted project's `.pi/conditional-hooks.json` to enable worktree cleanup after merge-shaped agent bash commands:
+
+```json
+{
+  "hooks": [
+    {
+      "name": "worktree-gc-on-merge",
+      "enabled": true,
+      "events": ["tool_result", "tool_execution_end"],
+      "when": {
+        "toolName": { "regex": "(^|\\.)bash$|^Bash$" },
+        "command": { "regex": "\\bgh\\s+pr\\s+merge\\b|\\bgit\\s+merge(?!-)\\b" },
+        "repoContains": "scripts/worktree-gc.ts"
+      },
+      "run": {
+        "command": "bun scripts/worktree-gc.ts --quiet",
+        "cwd": "repoRoot",
+        "timeout": 60000,
+        "print": true,
+        "appendToToolResult": true,
+        "ignoreFailure": true
+      }
+    }
+  ]
+}
+```
+
+The example runs only in repositories containing `scripts/worktree-gc.ts`; `run.cwd: "repoRoot"` runs the command from the resolved Git repository root.
+
+The merge regex is exactly `\\bgh\\s+pr\\s+merge\\b|\\bgit\\s+merge(?!-)\\b`. The `git\\s+merge(?!-)` part means `git merge-base --is-ancestor HEAD origin/main` must not trigger the hook.
+
+## Disable in a trusted project
+
+A trusted project can disable a same-named global hook:
+
+```json
+{
+  "hooks": [
+    {
+      "name": "worktree-gc-on-merge",
+      "enabled": false,
+      "events": ["tool_result"],
+      "when": {},
+      "run": {}
+    }
+  ]
+}
+```


### PR DESCRIPTION
Closes #20

## Acceptance criteria

- [x] `extensions/conditional-hooks/README.md` documents config locations, strict JSON syntax, merge-by-name project override behavior, `enabled: false`, and `/conditional-hooks`.
- [x] The worktree-GC example is valid JSON and includes the exact merge regex `\\bgh\\s+pr\\s+merge\\b|\\bgit\\s+merge(?!-)\\b`.
- [x] Docs explicitly say `git merge-base` must not trigger the example hook.
- [x] Docs explicitly say the worktree-GC behavior is not built in and must be enabled by config.
- [x] `README.md` links to the `conditional-hooks` extension README from the Pi extensions/resource list.
- [x] `docs/catalog.md` includes or updates the `conditional-hooks` entry.
- [x] `npm run check` passes.

## Functional evidence

```bash
python3 - <<'PY'
from pathlib import Path
import re,json
text=Path('extensions/conditional-hooks/README.md').read_text()
for block in re.findall(r'```json\\n(.*?)\\n```', text, re.S): json.loads(block)
assert '\\\\bgh\\\\s+pr\\\\s+merge\\\\b|\\\\bgit\\\\s+merge(?!-)\\\\b' in text
PY
npm run check
# ✓ JSON examples valid; lint, typecheck, smoke tests, plugin validation, resource inventory passed
```

## Self-review

- Scope stays inside issue #20: docs only.
- No hook filters, config installation, or Keepfolio verification added.
- Reviewer subagent returned `Ready — no blockers`.
