### PR TITLE
Add skill-inspector: skillspector wrapper with readable reports

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -26,6 +26,7 @@ Keep this as the human-readable record of what lives in the package.
 | `harness-audit` | Skill | `skills/harness-audit/SKILL.md` | active | Global-first skill with `~/.pi/agent/skills/harness-audit` symlinked here; audits repo harness readiness and fix gaps. |
 | `harness-worktrees` | Skill | `skills/harness-worktrees/SKILL.md` | active | Manages Pi/Superconductor worktree refreshes and resets after PR merges. |
 | `scaffold-notes` | Skill | `skills/scaffold-notes/SKILL.md` | active | Maintenance skill for adding resources to this repo consistently. |
+| `skill-inspector` | Skill | `skills/skill-inspector/SKILL.md` | active | Global-first skill (symlinked into `~/.claude/skills/skill-inspector`); security-scans agent skills with the `skillspector` CLI and renders a plain-English verdict report (safe/caution/do-not-install, threat breakdown, top findings) for chat. |
 | `critical-bug-hunt.prompt` | Prompt | `prompts/critical-bug-hunt.prompt.md` | active | Recent-commit audit prompt for high-severity correctness bugs and minimal fixes. |
 | `adversarial-review` | Claude Code Plugin | `claude-code/plugins/adversarial-review/.claude-plugin/plugin.json` | active | Adversarial implementation review — sends a structured prompt to a heavyweight reviewer to catch real bugs, returning a trinary verdict and a P0/P1/P2 fix list. |
 | `ask-codex` | Claude Code Plugin | `claude-code/plugins/ask-codex/.claude-plugin/plugin.json` | active | OpenAI Codex CLI integration — wraps `codex exec` / `codex resume` with model, reasoning-effort, and sandbox control. |

--- a/skills/skill-inspector/SKILL.md
+++ b/skills/skill-inspector/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: skill-inspector
+description: Security-inspect an AI agent skill (your own or a third party's) with the skillspector CLI, then deliver a plain-English verdict report in chat (safe / caution / do-not-install, threat breakdown, top findings to check, file hotspots). Use whenever Ossie wants to vet, scan, audit, or sanity-check a skill before installing or trusting it, points at a skill repo/folder/zip and asks "is this safe?", says "inspect this skill", "scan this skill", "check this skill for malware", "skillspector", or shares a GitHub link to a skill/agent and wants to know the risk. Also use to re-read confusing skillspector output.
+---
+
+# Skill Inspector
+
+Wraps the `skillspector` security scanner and renders its output as a report a human can actually read. skillspector finds risky patterns in agent skills (data exfiltration, credential access, code execution, prompt injection, persistence, malware signatures) and assigns a 0-100 risk score. Its raw output is hundreds of findings, which is unreadable. This skill collapses that into a verdict, a plain-English threat table, the findings worth checking first, and where they cluster.
+
+## When to reach for which mode
+
+- **Fast (default):** static + YARA rules only. No API keys, no cost, deterministic, always works. Use this for quick "is this safe?" checks. Pass `--no-llm`.
+- **Deep:** adds LLM analysis (intent classification, subtler findings). Needs a *working* provider + model in the environment. Slower, costs tokens. Only use when the fast scan is ambiguous and the extra depth is worth it.
+
+## Workflow
+
+Run the scanner, capture JSON + stderr, then render. Use a slug from the target so parallel scans don't collide. Resolve both paths at runtime (never hardcode a home path):
+
+```bash
+# skillspector binary: prefer PATH; otherwise the agentic-utilities repo venv.
+SKILLSPEC="$(command -v skillspector || true)"
+[ -z "$SKILLSPEC" ] && SKILLSPEC="$HOME/Projects/agentic-utilities/skillspector/.venv/bin/skillspector"
+
+# This skill's render script lives in scripts/ next to this SKILL.md.
+# Set SKILL_DIR to the directory this SKILL.md loaded from.
+SKILL_DIR="<dir-containing-this-SKILL.md>"
+SLUG=<short-name-of-target>          # e.g. agent-reach
+
+# 1. Scan (fast/static default). Accepts a Git URL, local dir, zip, .md, or file URL.
+#    Use 2>| (not 2>) so a re-scan with the same slug isn't blocked by zsh noclobber.
+"$SKILLSPEC" scan "<TARGET>" --no-llm \
+  --format json --output "/tmp/skillspector-$SLUG.json" \
+  2>| "/tmp/skillspector-$SLUG.stderr"
+
+# 2. Render the readable report
+python3 "$SKILL_DIR/scripts/render_report.py" \
+  "/tmp/skillspector-$SLUG.json" --scan-log "/tmp/skillspector-$SLUG.stderr"
+```
+
+For a **deep** scan, drop `--no-llm`. The scan exits non-zero whenever findings exist, which is normal, not a failure. Always render the JSON regardless of exit code.
+
+## Present the report
+
+The renderer prints chat-ready Markdown. **Paste it straight into the reply.** Don't re-summarize or re-format it; that's the deliverable. Then add at most one line of your own read (for example: "the YARA hits on a CHANGELOG and a PNG are likely false positives, the real concern is the credential-access cluster in `cli.py`").
+
+## How to read the result (so you can explain it)
+
+- **Verdict** is derived purely from the score band: SAFE (score 0-20), CAUTION (21-50), DO_NOT_INSTALL (51+). It's a heuristic, not a human judgment.
+- **The score saturates.** Each HIGH adds 25, each CRITICAL 50, capped at 100, then multiplied by 1.3 if the skill ships executable scripts. Two HIGH findings already max a small skill into the danger band. So 100/100 means "many red flags," not "maximally evil." The *findings* carry the signal, not the number. The report says this; reinforce it.
+- **Findings can be false positives.** A YARA `info_stealer` hit on a binary asset or a changelog, or "Env Variable Harvesting" inside a test file, is often benign. Static analysis flags patterns, not proven intent. Judge each cluster; don't treat every finding as a confirmed threat.
+- **Scan health matters.** If the report's "Scan health" section says the LLM fell back, a deep scan silently degraded to static. Say so, and offer to re-run once the provider is fixed.
+
+## Gotchas
+
+- **Broken LLM config is common.** If the environment sets `SKILLSPECTOR_MODEL` to a model the provider doesn't serve (a model that 404s), a non-`--no-llm` scan still produces a report but quietly falls back to static. The renderer detects this from stderr and flags it. Prefer `--no-llm` unless deep analysis is specifically wanted.
+- **Don't source a project `.env` just to scan.** The fast path needs no credentials. Sourcing a `.env` can drag in a broken `SKILLSPECTOR_MODEL`/provider and degrade the scan. Run clean.
+- **Exit code 1 is expected** when findings exist. Check that the JSON file was written, not the exit status.
+- **Big repos produce big JSON.** The raw report can be hundreds of KB. Never read it whole into context. The renderer reads it; you read the renderer's output. Point the user to the JSON path for full detail.

--- a/skills/skill-inspector/scripts/render_report.py
+++ b/skills/skill-inspector/scripts/render_report.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Render a skillspector JSON report into a concise, chat-ready Markdown summary.
+
+skillspector emits a flat list of up to hundreds of findings plus a raw 0-100
+risk score. Dumping that verbatim is unreadable. This script collapses the noise
+into a verdict, a plain-English threat table, the handful of finding-groups worth
+checking first, file hotspots, and a scan-health section — everything a human
+needs to decide "trust this skill or not" without scrolling through raw JSON.
+
+Results go to stdout (the Markdown report). Diagnostics go to stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+# Severity ordering and the per-finding weight skillspector uses to build the
+# 0-100 score (CRITICAL +50, HIGH +25, MEDIUM +10, LOW +5, x1.3 if the skill
+# ships executable scripts, capped at 100). We mirror it only to explain the
+# score honestly — it saturates fast, so it means "how many red flags", not a
+# precise danger dial.
+SEV_ORDER = {"CRITICAL": 4, "HIGH": 3, "MEDIUM": 2, "LOW": 1}
+SEV_ICON = {"CRITICAL": "🟥", "HIGH": "🟧", "MEDIUM": "🟨", "LOW": "🟦"}
+
+VERDICT_MEANING = {
+    "SAFE": "No serious risk patterns found. Reasonable to use after a glance.",
+    "CAUTION": "Some risky patterns. Read the findings below before you trust it.",
+    "DO_NOT_INSTALL": "Serious risk patterns. Do not install or run this until a human reviews the findings below.",
+}
+
+# Plain-English gloss for each threat category, faithful to skillspector's own
+# finding explanations. Keeps the report readable for non-security folks.
+CATEGORY_GLOSS = {
+    "Data Exfiltration": "Code that sends data out, or reads env vars/files that may hold secrets. Could be normal, could be theft.",
+    "Dangerous Code Execution": "Runs shell/external commands or eval-style code. Command-injection risk if inputs aren't checked.",
+    "Privilege Escalation": "Touches credential files (SSH keys, AWS creds) or asks for more access than it needs.",
+    "Excessive Agency": "Does things beyond its stated job (scope creep). An agent acting outside its documented purpose.",
+    "Memory Poisoning": "Tries to stuff or manipulate the context window, displacing your instructions and safety rules.",
+    "Output Handling": "Uses model/tool output without sanitizing it. Can feed injection into shell, SQL, or HTML downstream.",
+    "Rogue Agent": "Sets up persistence (cron, startup scripts, state files) to keep running across sessions.",
+    "Supply Chain": "Downloads and runs remote code. Bypasses review and can pull in anything later.",
+    "Tool Misuse": "Unsafe defaults (TLS off, no auth, world-writable) that widen the attack surface.",
+    "System Prompt Leakage": "Instructions that could expose system prompts or hidden rules to others.",
+    "YARA Match": "Matched a known-malware signature (reverse shell, backdoor, info-stealer, C2).",
+}
+
+
+def _load(path: str) -> dict:
+    try:
+        return json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.stderr.write(f"render_report: cannot read report {path}: {exc}\n")
+        sys.exit(2)
+
+
+def _scan_health(stderr_log: str | None, meta: dict) -> list[str]:
+    """Surface things that quietly degrade a scan: LLM fallback, crashes, exec scripts."""
+    notes: list[str] = []
+    if meta.get("has_executable_scripts"):
+        notes.append("📜 Ships **executable scripts**. Risk score was multiplied by 1.3, and scripts run code on your machine.")
+    if stderr_log and Path(stderr_log).exists():
+        log = Path(stderr_log).read_text().lower()
+        if "model_not_found" in log or "does not exist" in log:
+            notes.append("⚠️ The configured LLM model was rejected (404). Deep analysis **fell back to static-only**, so findings may be incomplete. Fix `SKILLSPECTOR_MODEL`/provider or run with `--no-llm` to make this intentional.")
+        elif "llm call failed" in log:
+            notes.append("⚠️ An LLM call failed. Some deep analysis fell back to static rules.")
+        if "traceback (most recent call last)" in log and "event loop is closed" not in log:
+            notes.append("⚠️ skillspector raised an error during the scan, so results may be partial. Re-run with `--verbose` to see why.")
+    return notes
+
+
+def _render(report: dict, raw_path: str, stderr_log: str | None) -> str:
+    skill = report.get("skill", {})
+    risk = report.get("risk_assessment", {})
+    issues = report.get("issues", [])
+    meta = report.get("metadata", {})
+
+    name = skill.get("name") or "unknown"
+    if name == "unknown":
+        name = Path(skill.get("source", raw_path)).name or "scanned skill"
+
+    rec = risk.get("recommendation", "CAUTION")
+    score = risk.get("score", 0)
+    band = risk.get("severity", "LOW")
+    mode = "static + LLM" if meta.get("llm_requested") else "static only"
+    files_flagged = len({i["location"].get("file") for i in issues if i.get("location")})
+
+    L: list[str] = []
+    L.append(f"# 🔍 Skill Security Report: `{name}`")
+    L.append("")
+    verdict_icon = "🛑" if rec == "DO_NOT_INSTALL" else ("⚠️" if rec == "CAUTION" else "✅")
+    L.append(f"> {verdict_icon} **Verdict: {rec.replace('_', ' ')}.** {VERDICT_MEANING.get(rec, '')}")
+    L.append(">")
+    L.append(f"> Risk score **{score}/100** ({band} band) · {len(issues)} findings across {files_flagged} files · skillspector {meta.get('skillspector_version', '?')} · {mode}")
+    L.append("")
+    if score >= 100:
+        L.append("**About the score:** it's capped at 100 and saturates fast (each HIGH adds 25, each CRITICAL 50). A 100 means \"lots of red flags,\" not a precise danger level. Read the findings, don't stop at the number.")
+        L.append("")
+
+    # Zero-findings short-circuit: no point rendering empty tables.
+    if not issues:
+        health = _scan_health(stderr_log, meta)
+        L.append("Nothing flagged by the scanner. Note that a clean static scan checks for *known* risky patterns; it isn't proof the skill is benign, just that nothing tripped the rules.")
+        if health:
+            L.append("")
+            L.append("## Scan health")
+            L.append("")
+            L.extend(health)
+        L.append("")
+        L.append("---")
+        L.append(f"_Raw report: `{raw_path}`_")
+        return "\n".join(L)
+
+    # At a glance — severity counts
+    sev_counts = Counter(i.get("severity", "LOW") for i in issues)
+    L.append("## At a glance")
+    L.append("")
+    L.append("| Severity | Count |")
+    L.append("|---|---|")
+    for sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW"):
+        if sev_counts.get(sev):
+            L.append(f"| {SEV_ICON[sev]} {sev} | {sev_counts[sev]} |")
+    L.append("")
+
+    # Threats found — by category, plain English
+    cat_counts = Counter(i.get("category", "Other") for i in issues)
+    L.append("## What it flagged (plain English)")
+    L.append("")
+    L.append("| Threat type | Hits | What it means |")
+    L.append("|---|---|---|")
+    for cat, n in cat_counts.most_common():
+        gloss = CATEGORY_GLOSS.get(cat, "(uncategorized)")
+        L.append(f"| **{cat}** | {n} | {gloss} |")
+    L.append("")
+
+    # Top findings — group by (category, pattern), HIGH+ first, collapse repeats
+    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for i in issues:
+        groups[(i.get("category", "Other"), i.get("pattern", "unspecified"))].append(i)
+
+    def group_rank(item):
+        (cat, pat), members = item
+        top_sev = max((SEV_ORDER.get(m.get("severity", "LOW"), 0) for m in members), default=0)
+        max_conf = max((m.get("confidence", 0) for m in members), default=0)
+        return (top_sev, len(members), max_conf)
+
+    ranked = sorted(groups.items(), key=group_rank, reverse=True)
+    # Show groups that are HIGH+; if none, fall back to the top MEDIUM groups.
+    high_groups = [g for g in ranked if max(SEV_ORDER.get(m.get("severity", "LOW"), 0) for m in g[1]) >= 3]
+    show = high_groups[:10] if high_groups else ranked[:6]
+
+    L.append("## Check these first")
+    L.append("")
+    if not show:
+        L.append("_Nothing high-severity to prioritize._")
+    for (cat, pat), members in show:
+        top_sev = max(members, key=lambda m: SEV_ORDER.get(m.get("severity", "LOW"), 0)).get("severity", "LOW")
+        max_conf = max((m.get("confidence", 0) for m in members), default=0)
+        example = members[0].get("location", {})
+        loc = f"{example.get('file', '?')}:{example.get('start_line', '?')}"
+        where = f"in `{loc}`" + (f" (+{len(members) - 1} more)" if len(members) > 1 else "")
+        L.append(f"- {SEV_ICON.get(top_sev, '')} **{cat} · {pat}**: {len(members)} hit(s), confidence up to {max_conf:.0%}. {where}")
+        remediation = (members[0].get("remediation") or "").strip().split("\n")[0]
+        if remediation:
+            L.append(f"  - _Fix:_ {remediation}")
+    L.append("")
+
+    # File hotspots
+    file_counts = Counter(i["location"].get("file") for i in issues if i.get("location"))
+    hot = [(f, n) for f, n in file_counts.most_common(5) if f]
+    if hot:
+        L.append("## Where the findings cluster")
+        L.append("")
+        for f, n in hot:
+            L.append(f"- `{f}`: {n} finding(s)")
+        L.append("")
+
+    # Scan health
+    health = _scan_health(stderr_log, meta)
+    if health:
+        L.append("## Scan health")
+        L.append("")
+        L.extend(health)
+        L.append("")
+
+    L.append("---")
+    L.append(f"_Full detail (every finding + remediation): `{raw_path}`_")
+    return "\n".join(L)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Render a skillspector JSON report as Markdown.")
+    ap.add_argument("report", help="Path to skillspector --format json report")
+    ap.add_argument("--scan-log", help="Path to captured stderr from the scan (for health warnings)")
+    args = ap.parse_args()
+    report = _load(args.report)
+    sys.stdout.write(_render(report, args.report, args.scan_log) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

New global-first skill `skill-inspector` that wraps the [skillspector](https://github.com/) security scanner and renders its output as a chat-ready report.

skillspector emits up to hundreds of raw findings plus a 0-100 risk score, which is unreadable. This skill collapses that into:
- a **verdict** (SAFE / CAUTION / DO_NOT_INSTALL) with plain-English meaning,
- a **threat table** glossing each agentic-threat category (data exfiltration, credential access, prompt injection, persistence, malware signatures, etc.),
- the **finding groups worth checking first** (HIGH+ collapsed by category/pattern, with remediation),
- **file hotspots**, and a **scan-health** section that flags when a deep LLM scan silently degrades to static fallback.

## Files
- `skills/skill-inspector/SKILL.md` — workflow, fast/deep mode guidance, gotchas
- `skills/skill-inspector/scripts/render_report.py` — deterministic JSON-to-Markdown renderer
- `docs/catalog.md` — catalog row (CI-required)

## Notes
- Defaults to fast static scans (`--no-llm`): no API keys, no cost, no rate limits. Validated that for a large repo the deep LLM pass added no findings over static while hitting provider rate limits.
- Paths resolved at runtime (`$HOME`/PATH/skill-relative) — no hardcoded home paths.
- Symlinked into `~/.claude/skills/` for global use; real files live here per the repo's global-first convention.

## Verification
`npm run check` ✅ · `npm run pack:dry` ✅ (skill packaged) · gitleaks ✅ · biome + tsc + smoke tests ✅ (pre-commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Skill Inspector resource entry to catalog
  * Added comprehensive guide covering usage, verdict levels (SAFE/CAUTION/DO_NOT_INSTALL), and scan modes

* **New Features**
  * Introduced security report generator that produces Markdown summaries with risk verdicts, severity breakdowns, threat analysis, prioritized findings by category, and scan health diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->